### PR TITLE
feat(auditing): 생성일, 수정일 추상 클래스 구현

### DIFF
--- a/src/main/java/com/pado/PadoApplication.java
+++ b/src/main/java/com/pado/PadoApplication.java
@@ -2,8 +2,10 @@ package com.pado;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PadoApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/pado/domain/baseTime/AuditingEntity.java
+++ b/src/main/java/com/pado/domain/baseTime/AuditingEntity.java
@@ -1,0 +1,22 @@
+package com.pado.domain.baseTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+/**
+ * 생성일과 수정일 모두 가지는 추상 클래스
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntity.class)
+public abstract class AuditingEntity extends CreatedAtEntity {
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/pado/domain/baseTime/CreatedAtEntity.java
+++ b/src/main/java/com/pado/domain/baseTime/CreatedAtEntity.java
@@ -1,0 +1,22 @@
+package com.pado.domain.baseTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+/**
+ * 생성일만 가지는 추상 클래스
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AutoCloseable.class)
+public abstract class CreatedAtEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}


### PR DESCRIPTION
## ✨ 요약

> 생성일, 수정일 추상클래스를 구현하여 필요한 엔티티에 상속할 수 있도록 한다.

## 🔗 작업 내용

- 생성일 추상 클래스 구현
- 수정일 추상 클래스 구현
- JPA Auditing 할성화

## 💻 상세 구현 내용

- 생성일 추상 클래스 `CreatedAtEntity` 구현
  - 생성일을 가지는 추상 클래스
- 수정일 추상 클래스 `AuditingAtEntity` 구현
  - 생성일, 수정일 모두 가지는 추상 클래스
- `PadoApplication` 클래스에 JPA Auditing 사용을 위한 `@EnableJpaAuditing` 추가

## 🔗 참고 사항

> 엔티티 구현 시 요구 사항에 맞게 구현한 추상 클래스를 상속해서 사용하시면 됩니다. 
## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #9 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)