### PR TITLE
feat: 프로젝트 배포를 위한 Docker 및 운영 환경 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:21-jdk-slim
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,4 +4,9 @@
 # spring.datasource.username=DB??
 # spring.datasource.password=DB????
 
+spring.datasource.url=jdbc:mysql://${DB_URL}:3306/mydatabase?useSSL=false
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+
 spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
## ✨ 요약

> EC2 서버 배포를 위해 프로젝트에 Docker 설정을 추가하고, 운영 환경(prod)에서 사용할 application.properties를 구성합니다. 이 PR이 머지되면 프로젝트를 Docker 이미지로 빌드하고 실행할 수 있는 준비가 완료됩니다.

## 🔗 작업 내용

- 운영 환경(prod) 프로필용 설정 파일(application-prod.properties)을 수정하여, DB 접속 정보를 환경 변수로부터 읽어오도록 변경했습니다.
- 프로젝트를 Docker 이미지로 빌드하기 위한 Dockerfile을 프로젝트 루트에 추가했습니다.


## 💻 상세 구현 내용

> 위와 같습니다.

## 🔗 참고 사항

> 이 PR은 EC2 수동 배포를 위한 사전 준비 작업입니다.
> 팀 논의에 따라 Flyway는 현재 포함하지 않았으며, ddl-auto는 none으로 설정되어 있습니다. 따라서 최초 배포 시 서버 DB 스키마는 수동으로 생성해주어야 합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #11 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)