### PR TITLE
fix: 배포 환경 Swagger CORS 오류 해결

### DIFF
--- a/src/main/java/com/pado/global/config/CorsConfig.java
+++ b/src/main/java/com/pado/global/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package com.pado.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins(
+                        "https://gogumalatte.site",
+                        "http://localhost:3000"
+                )
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}


### PR DESCRIPTION
## ✨ 요약
배포 환경에서 Swagger UI 실행 시 발생하던 CORS 오류를 해결하기 위해 /api/** 경로에 CORS 설정을 추가했습니다.

## 🔗 작업 내용
- /api/** 경로에 CORS 정책 적용
- 배포 환경 도메인 허용
- 로컬 개발 환경 도메인(http://localhost:3000) 허용

## 💻 상세 구현 내용
Swagger UI에서 API 실행 시 Failed to fetch CORS 오류가 발생했습니다.
이를 해결하기 위해 WebMvcConfigurer를 구현한 CorsConfig 클래스를 추가하여 /api/** 경로에 대한 CORS 설정을 적용했습니다.
허용 도메인, HTTP 메서드, 헤더, 인증 정보, pre-flight 캐시 시간 등을 명시했습니다.

## 🔗 참고 사항


## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #19

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)