### PR TITLE
fix(deploy): Blue/Green 배포 시 Docker 컨테이너 DB 연결 문제 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,8 +82,8 @@ jobs:
             sudo docker pull $DOCKER_USERNAME/$APP_NAME:$IMAGE_TAG
             
             NEW_CONTAINER_ID=$(sudo docker run -d -p ${TARGET_PORT}:8080 \
+              --add-host host.docker.internal:host-gateway
               -e SPRING_PROFILES_ACTIVE=prod \
-              -e DB_URL=${{ secrets.DB_URL }} \
               -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
               -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
               $DOCKER_USERNAME/$APP_NAME:$IMAGE_TAG)

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -3,11 +3,8 @@
 # spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 # spring.datasource.username=DB??
 # spring.datasource.password=DB????
-
-spring.datasource.url=jdbc:mysql://${DB_URL}:3306/padodatabase?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
-
+spring.datasource.url=jdbc:mysql://host.docker.internal:3306/padodatabase?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
-
 spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
## ✨ 요약

> blue/green 무중단 배포 환경에서 Docker 컨테이너가 EC2 호스트의 MySQL 데이터베이스에 안정적으로 연결할 수 있도록 관련 설정을 수정했습니다.

## 🔗 작업 내용

- DB 접속 URL의 호스트 주소를 127.0.0.1이나 외부 주입 변수가 아닌, host.docker.internal로 고정합니다.
- docker run 명령어에 --add-host host.docker.internal:host-gateway 옵션을 추가하여 컨테이너가 호스트 서버를 인식할 수 있도록 설정합니다.

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #37 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)