### PR TITLE
feat: CI/CD 파이프라인 env-file 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,7 +148,7 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/pado-app:${{ steps.vars.outputs.sha_short }}
 
-      - name: EC2 remote smoke on temp port
+      - name: EC2 remote smoke on temp port (env-file)
         uses: appleboy/ssh-action@v0.1.10
         with:
           host: ${{ secrets.EC2_HOST }}
@@ -162,35 +162,44 @@ jobs:
             IMAGE="$DOCKER_USERNAME/$APP_NAME:$IMAGE_TAG"
             PORT=18080
             NAME="pado-pr-${{ github.run_id }}"
-
+            
             echo "Pull $IMAGE and run on localhost:${PORT} ..."
             sudo docker pull "$IMAGE"
             sudo docker rm -f "$NAME" 2>/dev/null || true
-
+            
+            # Create PR env file on remote (prevent expansion with quoted heredoc)
+            cat > /tmp/pado-pr.env <<'EOF'
+            SPRING_PROFILES_ACTIVE=prod
+            DB_USERNAME=${{ secrets.DB_USERNAME }}
+            DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+            AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}
+            AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}
+            MAIL_HOST=${{ secrets.MAIL_HOST }}
+            MAIL_PORT=${{ secrets.MAIL_PORT }}
+            MAIL_USERNAME=${{ secrets.MAIL_USERNAME }}
+            MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}
+            JWT_SECRET=${{ secrets.JWT_SECRET }}
+            JWT_ACCESS_EXP_SECONDS=${{ secrets.JWT_ACCESS_EXP_SECONDS || '3600' }}
+            EOF
+            
             NEW_ID=$(sudo docker run -d --name "$NAME" -p ${PORT}:8080 \
               --add-host host.docker.internal:host-gateway \
-              -e SPRING_PROFILES_ACTIVE=prod \
-              -e JWT_SECRET='${{ secrets.JWT_SECRET }}' \
-              -e JWT_ACCESS_EXP_SECONDS='${{ secrets.JWT_ACCESS_EXP_SECONDS || '3600' }}' \
-              -e DB_USERNAME='${{ secrets.DB_USERNAME }}' \
-              -e DB_PASSWORD='${{ secrets.DB_PASSWORD }}' \
-              -e SPRING_MAIL_HOST='${{ secrets.MAIL_HOST }}' \
-              -e SPRING_MAIL_PORT='${{ secrets.MAIL_PORT }}' \
-              -e SPRING_MAIL_USERNAME='${{ secrets.MAIL_USERNAME }}' \
-              -e SPRING_MAIL_PASSWORD='${{ secrets.MAIL_PASSWORD }}' \
+              --env-file /tmp/pado-pr.env \
               "$IMAGE")
-
+            
             if [ -z "$NEW_ID" ]; then
-              echo "docker run failed"; exit 1
+              echo "docker run failed"
+              sudo shred -u /tmp/pado-pr.env || sudo rm -f /tmp/pado-pr.env || true
+              exit 1
             fi
-
+            
             HEALTH="http://127.0.0.1:${PORT}/actuator/health"
             for i in $(seq 1 12); do
               echo "PR EC2 health check #$i ..."
               if curl -s --fail "$HEALTH" | grep -q '"status":"UP"'; then OK=true; break; fi
               sleep 5
             done
-
+            
             if [ "${OK:-false}" != true ]; then
               echo "--- Health response ---"
               curl -s "$HEALTH" || true
@@ -198,10 +207,12 @@ jobs:
               echo "--- Logs ---"
               sudo docker logs "$NAME" || true
               sudo docker rm -f "$NAME" || true
+              sudo shred -u /tmp/pado-pr.env || sudo rm -f /tmp/pado-pr.env || true
               exit 1
             fi
-
+            
             sudo docker rm -f "$NAME" || true
+            sudo shred -u /tmp/pado-pr.env || sudo rm -f /tmp/pado-pr.env || true
             echo "PR EC2 smoke passed."
 
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,6 @@ jobs:
           set -euo pipefail
           docker run -d --name pado-smoke -p 18080:8080 \
             -e SPRING_PROFILES_ACTIVE=dev \
-            -e MANAGEMENT_HEALTH_MAIL_ENABLED=false \
             pado-app:${{ github.sha }}
       - name: Wait for health (status:UP)
         run: |
@@ -175,8 +174,6 @@ jobs:
               -e JWT_ACCESS_EXP_SECONDS='${{ secrets.JWT_ACCESS_EXP_SECONDS || '3600' }}' \
               -e DB_USERNAME='${{ secrets.DB_USERNAME }}' \
               -e DB_PASSWORD='${{ secrets.DB_PASSWORD }}' \
-              -e AWS_ACCESS_KEY='${{ secrets.AWS_ACCESS_KEY }}' \
-              -e AWS_SECRET_KEY='${{ secrets.AWS_SECRET_KEY }}' \
               -e SPRING_MAIL_HOST='${{ secrets.MAIL_HOST }}' \
               -e SPRING_MAIL_PORT='${{ secrets.MAIL_PORT }}' \
               -e SPRING_MAIL_USERNAME='${{ secrets.MAIL_USERNAME }}' \
@@ -206,7 +203,6 @@ jobs:
 
             sudo docker rm -f "$NAME" || true
             echo "PR EC2 smoke passed."
-
 
   build-and-deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
@@ -254,7 +250,7 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/pado-app:${{ steps.vars.outputs.sha_short }}
             ${{ secrets.DOCKERHUB_USERNAME }}/pado-app:latest
 
-      - name: Deploy to EC2 (Blue/Green)
+      - name: Deploy to EC2 (Blue/Green) with env-file
         uses: appleboy/ssh-action@v0.1.10
         with:
           host: ${{ secrets.EC2_HOST }}
@@ -280,26 +276,31 @@ jobs:
               sudo docker rm -f "$NEW_NAME"
             fi
 
+            cat > /tmp/pado.env <<'EOF'
+            SPRING_PROFILES_ACTIVE=prod
+            DB_USERNAME=${{ secrets.DB_USERNAME }}
+            DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+            AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}
+            AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}
+            MAIL_HOST=${{ secrets.MAIL_HOST }}
+            MAIL_PORT=${{ secrets.MAIL_PORT }}
+            MAIL_USERNAME=${{ secrets.MAIL_USERNAME }}
+            MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}
+            JWT_SECRET=${{ secrets.JWT_SECRET }}
+            JWT_ACCESS_EXP_SECONDS=${{ secrets.JWT_ACCESS_EXP_SECONDS }}
+            EOF
+            
             NEW_CONTAINER_ID=$(sudo docker run -d --name "$NEW_NAME" -p ${TARGET_PORT}:8080 \
               --add-host host.docker.internal:host-gateway \
-              -e SPRING_PROFILES_ACTIVE=prod \
-              -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
-              -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
-              -e AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }} \
-              -e AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }} \
-              -e MAIL_HOST=${{ secrets.MAIL_HOST }} \
-              -e MAIL_PORT=${{ secrets.MAIL_PORT }} \
-              -e MAIL_USERNAME=${{ secrets.MAIL_USERNAME }} \
-              -e MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }} \
-              -e JWT_SECRET=${{ secrets.JWT_SECRET }} \
-              -e JWT_ACCESS_EXP_SECONDS=${{ secrets.JWT_ACCESS_EXP_SECONDS }} \
+              --env-file /tmp/pado.env \
               "$IMAGE")
-
+            
             if [ -z "$NEW_CONTAINER_ID" ]; then
               echo "ERROR: docker run did not return a container ID"
+              sudo shred -u /tmp/pado.env || sudo rm -f /tmp/pado.env || true
               exit 1
             fi
-
+            
             echo "Started $NEW_NAME ($NEW_CONTAINER_ID) on :$TARGET_PORT. Health check..."
             HEALTH_CHECK_URL="http://127.0.0.1:${TARGET_PORT}/actuator/health"
             for i in $(seq 1 12); do
@@ -309,18 +310,18 @@ jobs:
               fi
               sleep 5
             done
-
+            
             if [ "${HEALTH_OK:-false}" = true ]; then
               sudo sed -i "s/server 127.0.0.1:.*/server 127.0.0.1:${TARGET_PORT};/" "$NGINX_CONF_PATH"
               sudo nginx -t && sudo systemctl reload nginx
-
+            
               if [ -n "$CURRENT_PORT" ]; then
                 OLD_ID=$(sudo docker ps -q --filter "publish=${CURRENT_PORT}")
-                if [ -n "$OLD_ID" ]; then
-                  sudo docker rm -f "$OLD_ID"
-                fi
+                  if [ -n "$OLD_ID" ]; then
+                    sudo docker rm -f "$OLD_ID"
+                  fi
               fi
-
+            
               sudo docker image prune -f
               echo "Deployment complete."
             else
@@ -330,5 +331,8 @@ jobs:
               echo "--- Container logs ($NEW_NAME) ---"
               sudo docker logs "$NEW_NAME" || true
               sudo docker rm -f "$NEW_NAME" || true
+              sudo shred -u /tmp/pado.env || sudo rm -f /tmp/pado.env || true
               exit 1
             fi
+
+            sudo shred -u /tmp/pado.env || sudo rm -f /tmp/pado.env || true

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -22,7 +22,4 @@ logging.level.org.springframework.cloud.aws=DEBUG
 app.jwt.secret=dev-secret-key-1234567890abcdef1234567890abcd
 app.jwt.access-exp-seconds=36000
 # mail
-spring.mail.host=localhost
-spring.mail.port=2525
-spring.mail.username=dummy
-spring.mail.password=dummy
+management.health.mail.enabled=false

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -22,4 +22,8 @@ logging.level.org.springframework.cloud.aws=DEBUG
 app.jwt.secret=dev-secret-key-1234567890abcdef1234567890abcd
 app.jwt.access-exp-seconds=36000
 # mail
+spring.mail.host=localhost
+spring.mail.port=2525
+spring.mail.username=dummy
+spring.mail.password=dummy
 management.health.mail.enabled=false


### PR DESCRIPTION
## ✨ 요약

- pr을 할 때 ci/cd 파이프라인은 모두 통과했으나,  develop 머지 시 build-and-deploy 단계에서 docker run -e 인자 내 시크릿의 $가 확장되어 set -u 환경에서 “unbound variable”가 발생하는 문제가 있었습니다.
- 시크릿에 쌍따움표를 추가하는 방법도 있으나,  문자열이 조기 종료되어 구문 오류가 생겨 근본적인 해결이 안될 우려가 있습니다.
- 따라서 원격 호스트에서 임시 .env를 만들고 docker run --env-file /tmp/app.env로 주입하는 방식을 도입했습니다.

## 🔗 작업 내용

- build-and-deploy에서 env-file 방식 도입
- 사전에 체크할 수 있게 pr-ec2-smoke에서도 env-file 방식 도입


## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

## 🔗 참고 사항

> 이제 cicd 그만 터졌으면 좋겠습니다..😭

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #61 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)