### PR TITLE
feat: 자료 관리 CRUD 완전 구현

### DIFF
--- a/src/main/java/com/pado/domain/material/entity/File.java
+++ b/src/main/java/com/pado/domain/material/entity/File.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 
 @Getter
 @Entity
-@Table(name = "file")
+@Table(name = "material_file")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class File {
 

--- a/src/main/java/com/pado/domain/material/entity/Material.java
+++ b/src/main/java/com/pado/domain/material/entity/Material.java
@@ -1,6 +1,8 @@
 package com.pado.domain.material.entity;
 
 import com.pado.domain.basetime.AuditingEntity;
+import com.pado.domain.study.entity.Study;
+import com.pado.domain.user.entity.User;
 import com.pado.global.exception.common.BusinessException;
 import com.pado.global.exception.common.ErrorCode;
 import jakarta.persistence.*;
@@ -31,23 +33,15 @@ public class Material extends AuditingEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    // TODO: 추후 User, Study 엔티티 연관관계 활성화
-    // @ManyToOne(fetch = FetchType.LAZY)
-    // @JoinColumn(name = "user_id", nullable = false)
-    // private User user;
+     @ManyToOne(fetch = FetchType.LAZY)
+     @JoinColumn(name = "user_id", nullable = false)
+     private User user;
 
-    // @ManyToOne(fetch = FetchType.LAZY)
-    // @JoinColumn(name = "study_id", nullable = false)
-    // private Study study;
+     @ManyToOne(fetch = FetchType.LAZY)
+     @JoinColumn(name = "study_id", nullable = false)
+     private Study study;
 
-    // 임시로 studyId와 userId를 직접 저장 (추후 연관관계로 변경)
-    @Column(name = "study_id", nullable = false)
-    private Long studyId;
-
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
-
-    public Material(String title, MaterialCategory materialCategory, Integer week, String content, Long studyId, Long userId) {
+    public Material(String title, MaterialCategory materialCategory, Integer week, String content, Study study, User user) {
 
         validateCategoryAndWeek(materialCategory, week);
 
@@ -55,8 +49,8 @@ public class Material extends AuditingEntity {
         this.materialCategory = materialCategory;
         this.week = week;
         this.content = content;
-        this.studyId = studyId;
-        this.userId = userId;
+        this.study = study;
+        this.user = user;
     }
 
     public void updateMaterial(String title, MaterialCategory materialCategory, Integer week, String content) {
@@ -69,8 +63,9 @@ public class Material extends AuditingEntity {
         this.content = content;
     }
 
-    public boolean isOwnedBy(Long userId) {
-        return this.userId.equals(userId);
+    public boolean isOwnedBy(User user) {
+
+        return this.user.getId().equals(user.getId());
     }
 
     public boolean isLearningMaterial() {

--- a/src/main/java/com/pado/domain/material/repository/MaterialRepository.java
+++ b/src/main/java/com/pado/domain/material/repository/MaterialRepository.java
@@ -12,25 +12,10 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface MaterialRepository extends JpaRepository<Material, Long> {
+public interface MaterialRepository extends JpaRepository<Material, Long>, MaterialRepositoryCustom {
 
     // 기본 조회 (@PageableDefault의 정렬 적용)
     Page<Material> findByStudyId(Long studyId, Pageable pageable);
-    
-    // 통합 검색 (카테고리 + 주차 + 키워드) (Pageable의 정렬 설정 적용)
-    @Query("SELECT m FROM Material m WHERE m.studyId = :studyId " +
-            "AND (:categories IS NULL OR m.materialCategory IN :categories) " +
-            "AND (:weeks IS NULL OR m.week IN :weeks OR (m.materialCategory != 'LEARNING' AND :weeks IS NOT NULL)) " +
-            "AND (:keyword IS NULL OR " +
-            "     m.title LIKE CONCAT('%', :keyword, '%') OR " +
-            "     m.content LIKE CONCAT('%', :keyword, '%'))")
-    Page<Material> findByStudyIdWithFiltersAndKeyword(
-            @Param("studyId") Long studyId,
-            @Param("categories") List<MaterialCategory> categories,
-            @Param("weeks") List<String> weeks,
-            @Param("keyword") String keyword,
-            Pageable pageable
-    );
 
     List<Material> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/pado/domain/material/repository/MaterialRepository.java
+++ b/src/main/java/com/pado/domain/material/repository/MaterialRepository.java
@@ -33,8 +33,4 @@ public interface MaterialRepository extends JpaRepository<Material, Long> {
     );
 
     List<Material> findByIdIn(List<Long> ids);
-    
-    boolean existsByIdAndUserId(Long id, Long userId);
-    
-    boolean existsByIdAndStudyId(Long materialId, Long studyId);
 }

--- a/src/main/java/com/pado/domain/material/repository/MaterialRepositoryCustom.java
+++ b/src/main/java/com/pado/domain/material/repository/MaterialRepositoryCustom.java
@@ -1,0 +1,18 @@
+package com.pado.domain.material.repository;
+
+import com.pado.domain.material.entity.Material;
+import com.pado.domain.material.entity.MaterialCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface MaterialRepositoryCustom {
+    Page<Material> findByStudyIdWithFiltersAndKeyword(
+            Long studyId,
+            List<MaterialCategory> categories,
+            List<String> weeks,
+            String keyword,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/pado/domain/material/service/MaterialService.java
+++ b/src/main/java/com/pado/domain/material/service/MaterialService.java
@@ -3,6 +3,7 @@ package com.pado.domain.material.service;
 import com.pado.domain.material.dto.request.MaterialRequestDto;
 import com.pado.domain.material.dto.response.MaterialDetailResponseDto;
 import com.pado.domain.material.dto.response.MaterialListResponseDto;
+import com.pado.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -10,13 +11,14 @@ import java.util.List;
 public interface MaterialService {
 
     // 자료 생성
-    MaterialDetailResponseDto createMaterial(Long studyId, MaterialRequestDto request);
+    MaterialDetailResponseDto createMaterial(User user , Long studyId, MaterialRequestDto request);
 
     // 자료 단일 조회
-    MaterialDetailResponseDto findMaterialById(Long materialId);
+    MaterialDetailResponseDto findMaterialById(User user ,Long materialId);
 
     // 자료 목록 조회 (페이징, 카테고리 필터, 주차 필터, 키워드 검색)
     MaterialListResponseDto findAllMaterials(
+            User user,
             Long studyId,
             List<String> categories,
             List<String> weeks,
@@ -25,8 +27,8 @@ public interface MaterialService {
     );
 
     // 자료 수정
-    MaterialDetailResponseDto updateMaterial(Long materialId, MaterialRequestDto request);
+    MaterialDetailResponseDto updateMaterial(User user, Long materialId, MaterialRequestDto request);
 
     // 자료 삭제 (단일 또는 다중)
-    void deleteMaterial(List<Long> ids);
+    void deleteMaterial(User user, List<Long> ids);
 }

--- a/src/main/java/com/pado/domain/material/service/MaterialServiceImpl.java
+++ b/src/main/java/com/pado/domain/material/service/MaterialServiceImpl.java
@@ -250,12 +250,6 @@ public class MaterialServiceImpl implements MaterialService {
         return materials;
     }
 
-    // 유저의 ID를 가져오는 메서드
-    private Long getCurrentUserId() {
-        // TODO: 토큰을 통해 실제 사용자 ID 가져오기
-        return 1L;
-    }
-
     // 자료 상세 조회 DTO 변환 메서드
     private MaterialDetailResponseDto convertToDetailResponseDto(Material material) {
         List<File> files = fileRepository.findByMaterialId(material.getId());
@@ -270,7 +264,7 @@ public class MaterialServiceImpl implements MaterialService {
                 material.getWeek(),
                 material.getContent(),
                 material.getUser().getId(),
-                "임시 닉네임",
+                material.getUser().getNickname(),
                 material.getCreatedAt(),
                 material.getUpdatedAt(),
                 fileResponseDtos
@@ -289,7 +283,7 @@ public class MaterialServiceImpl implements MaterialService {
                 material.getMaterialCategory().name,
                 material.getWeek(),
                 material.getUser().getId(),
-                "임시 닉네임",
+                material.getUser().getNickname(),
                 dataUrls,
                 material.getCreatedAt()
         );

--- a/src/main/java/com/pado/domain/s3/service/S3Service.java
+++ b/src/main/java/com/pado/domain/s3/service/S3Service.java
@@ -30,6 +30,9 @@ public class S3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
+    @Value("${cloud.aws.s3.prefix}")
+    private String s3Prefix;
+
     // 파일 업로드용
     public UploadPreSignedUrlResponseDto createUploadPresignedUrl(UploadFilePreSignedUrlRequestDto request) {
         String fileName = request.name();
@@ -148,13 +151,13 @@ public class S3Service {
             extension = fileName.substring(fileName.lastIndexOf("."));
         }
 
-        return uuid + extension;
+        return s3Prefix + uuid + extension;
     }
 
     // 사진 다운로드 용 키 생성
     private String generateImageKey(String contentType) {
         String extension = getFileExtensionFromContentType(contentType);
-        return UUID.randomUUID().toString() + extension;
+        return s3Prefix + UUID.randomUUID().toString() + extension;
     }
 
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -18,6 +18,7 @@ logging.level.org.hibernate.orm.jdbc.bind=TRACE
 cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
 cloud.aws.s3.bucket=pado-storage
+cloud.aws.s3.prefix=dev/
 
 # aws logging
 logging.level.com.amazonaws=DEBUG

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -26,6 +26,7 @@ spring.mail.default-encoding=UTF-8
 cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
 cloud.aws.s3.bucket=pado-storage
+cloud.aws.s3.prefix=prod/
 
 # aws logging
 logging.level.com.amazonaws=WARN

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -32,6 +32,8 @@ CREATE TABLE IF NOT EXISTS email_verifications (
 CREATE INDEX IF NOT EXISTS idx_email_verifications_email
     ON email_verifications (email);
 
+DROP TABLE IF EXISTS material_file;
+DROP TABLE IF EXISTS material;
 DROP TABLE IF EXISTS study_member;
 DROP TABLE IF EXISTS study_application;
 DROP TABLE IF EXISTS study_category;
@@ -101,4 +103,26 @@ CREATE TABLE study_member (
   CONSTRAINT uk_study_member_study_user UNIQUE (study_id, user_id),
   CONSTRAINT fk_study_member_study FOREIGN KEY (study_id) REFERENCES study (id) ON DELETE CASCADE,
   CONSTRAINT fk_study_member_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE TABLE material (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    material_category VARCHAR(50) NOT NULL,
+    week INT COMMENT,
+    content TEXT NOT NULL,
+    user_id BIGINT NOT NULL,
+    study_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_material_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    CONSTRAINT fk_material_study FOREIGN KEY (study_id) REFERENCES study (id) ON DELETE CASCADE
+);
+
+CREATE TABLE material_file (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    file_key VARCHAR(255) NOT NULL,
+    material_id BIGINT NOT NULL,
+    CONSTRAINT fk_material_file_material FOREIGN KEY (material_id) REFERENCES material (id) ON DELETE CASCADE
 );

--- a/src/test/java/com/pado/domain/material/repository/FileRepositoryTest.java
+++ b/src/test/java/com/pado/domain/material/repository/FileRepositoryTest.java
@@ -1,0 +1,227 @@
+package com.pado.domain.material.repository;
+
+import com.pado.domain.material.entity.File;
+import com.pado.domain.material.entity.Material;
+import com.pado.domain.material.entity.MaterialCategory;
+import com.pado.domain.study.entity.Study;
+import com.pado.domain.study.repository.StudyRepository;
+import com.pado.domain.user.entity.User;
+import com.pado.domain.user.entity.Gender;
+import com.pado.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import com.pado.global.config.QueryDslConfig;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+class FileRepositoryTest {
+
+    @Autowired
+    private FileRepository fileRepository;
+
+    @Autowired
+    private MaterialRepository materialRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StudyRepository studyRepository;
+
+    private User testUser;
+    private Study testStudy;
+    private Material testMaterial1;
+    private Material testMaterial2;
+    private File file1;
+    private File file2;
+    private File file3;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 사용자 생성
+        testUser = User.builder()
+                .email("test@example.com")
+                .nickname("testUser")
+                .passwordHash("password")
+                .gender(Gender.MALE)
+                .build();
+        testUser = userRepository.save(testUser);
+
+        // 테스트 스터디 생성
+        testStudy = Study.builder()
+                .title("Test Study")
+                .description("Test Description")
+                .maxMembers(10)
+                .region(com.pado.domain.shared.entity.Region.SEOUL)
+                .leader(testUser)
+                .build();
+        testStudy = studyRepository.save(testStudy);
+
+        // 테스트 자료들 생성
+        testMaterial1 = new Material(
+                "자료 1",
+                MaterialCategory.LEARNING,
+                1,
+                "내용 1",
+                testStudy,
+                testUser
+        );
+
+        testMaterial2 = new Material(
+                "자료 2",
+                MaterialCategory.NOTICE,
+                null,
+                "내용 2",
+                testStudy,
+                testUser
+        );
+
+        testMaterial1 = materialRepository.save(testMaterial1);
+        testMaterial2 = materialRepository.save(testMaterial2);
+
+        // 테스트 파일들 생성
+        file1 = new File("file1.pdf", "s3-key-1");
+        file1.setMaterial(testMaterial1);
+
+        file2 = new File("file2.docx", "s3-key-2");
+        file2.setMaterial(testMaterial1);
+
+        file3 = new File("file3.jpg", "s3-key-3");
+        file3.setMaterial(testMaterial2);
+
+        fileRepository.saveAll(Arrays.asList(file1, file2, file3));
+    }
+
+    @Test
+    void 자료ID로_파일목록_조회() {
+        // when
+        List<File> result = fileRepository.findByMaterialId(testMaterial1.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting("name")
+                .containsExactlyInAnyOrder("file1.pdf", "file2.docx");
+        assertThat(result).extracting("fileKey")
+                .containsExactlyInAnyOrder("s3-key-1", "s3-key-2");
+    }
+
+    @Test
+    @DisplayName("자료 ID 목록으로 파일들 조회")
+    void findByMaterialIdIn_Success() {
+        // given
+        List<Long> materialIds = Arrays.asList(testMaterial1.getId(), testMaterial2.getId());
+
+        // when
+        List<File> result = fileRepository.findByMaterialIdIn(materialIds);
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting("name")
+                .containsExactlyInAnyOrder("file1.pdf", "file2.docx", "file3.jpg");
+    }
+
+    @Test
+    void 자료ID로_파일삭제() {
+        // given
+        Long materialId = testMaterial1.getId();
+
+        // when
+        fileRepository.deleteByMaterialId(materialId);
+
+        // then
+        List<File> remainingFiles = fileRepository.findByMaterialId(materialId);
+        assertThat(remainingFiles).isEmpty();
+
+        List<File> otherMaterialFiles = fileRepository.findByMaterialId(testMaterial2.getId());
+        assertThat(otherMaterialFiles).hasSize(1);
+    }
+
+    @Test
+    void 파일키_목록으로_파일삭제() {
+        // given
+        List<String> fileKeys = Arrays.asList("s3-key-1", "s3-key-3");
+
+        // when
+        fileRepository.deleteAllByFileKeyIn(fileKeys);
+
+        // then
+        List<File> remainingFiles = fileRepository.findAll();
+        assertThat(remainingFiles).hasSize(1);
+        assertThat(remainingFiles.getFirst().getFileKey()).isEqualTo("s3-key-2");
+    }
+
+    @Test
+    void 존재하지_않는_자료ID로_파일조회() {
+        // given
+        Long nonExistentMaterialId = 999L;
+
+        // when
+        List<File> result = fileRepository.findByMaterialId(nonExistentMaterialId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void 존재하지_않는_자료ID_목록으로_파일조회() {
+        // given
+        List<Long> nonExistentMaterialIds = Arrays.asList(999L, 1000L);
+
+        // when
+        List<File> result = fileRepository.findByMaterialIdIn(nonExistentMaterialIds);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void 존재하지_않는_파일키로_삭제() {
+        // given
+        List<String> nonExistentFileKeys = Arrays.asList("non-existent-key-1", "non-existent-key-2");
+        int initialCount = fileRepository.findAll().size();
+
+        // when
+        fileRepository.deleteAllByFileKeyIn(nonExistentFileKeys);
+
+        // then
+        List<File> remainingFiles = fileRepository.findAll();
+        assertThat(remainingFiles).hasSize(initialCount);
+    }
+
+    @Test
+    void 빈_자료ID_목록으로_파일_조회() {
+        // given
+        List<Long> emptyMaterialIds = Arrays.asList();
+
+        // when
+        List<File> result = fileRepository.findByMaterialIdIn(emptyMaterialIds);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void 빈_파일키_목록으로_삭제() {
+        // given
+        List<String> emptyFileKeys = Arrays.asList();
+        int initialCount = fileRepository.findAll().size();
+
+        // when
+        fileRepository.deleteAllByFileKeyIn(emptyFileKeys);
+
+        // then
+        List<File> remainingFiles = fileRepository.findAll();
+        assertThat(remainingFiles).hasSize(initialCount); // 개수 변화 없음
+    }
+}

--- a/src/test/java/com/pado/domain/material/repository/MaterialRepositoryTest.java
+++ b/src/test/java/com/pado/domain/material/repository/MaterialRepositoryTest.java
@@ -1,0 +1,214 @@
+package com.pado.domain.material.repository;
+
+import com.pado.domain.material.entity.Material;
+import com.pado.domain.material.entity.MaterialCategory;
+import com.pado.domain.study.entity.Study;
+import com.pado.domain.study.repository.StudyRepository;
+import com.pado.domain.user.entity.User;
+import com.pado.domain.user.entity.Gender;
+import com.pado.domain.user.repository.UserRepository;
+import com.pado.global.config.QueryDslConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+class MaterialRepositoryTest {
+
+    @Autowired
+    private MaterialRepository materialRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StudyRepository studyRepository;
+
+    private User testUser;
+    private Study testStudy;
+    private Material learningMaterial1;
+    private Material learningMaterial2;
+    private Material noticeMaterial;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .email("test@example.com")
+                .nickname("testUser")
+                .passwordHash("password")
+                .gender(Gender.MALE)
+                .build();
+        testUser = userRepository.save(testUser);
+
+        testStudy = Study.builder()
+                .title("Test Study")
+                .description("Test Description")
+                .maxMembers(10)
+                .region(com.pado.domain.shared.entity.Region.SEOUL)
+                .leader(testUser)
+                .build();
+        testStudy = studyRepository.save(testStudy);
+
+        learningMaterial1 = new Material(
+                "학습자료 1주차",
+                MaterialCategory.LEARNING,
+                1,
+                "1주차 학습 내용입니다.",
+                testStudy,
+                testUser
+        );
+
+        learningMaterial2 = new Material(
+                "학습자료 2주차",
+                MaterialCategory.LEARNING,
+                2,
+                "2주차 학습 내용입니다.",
+                testStudy,
+                testUser
+        );
+
+        noticeMaterial = new Material(
+                "중요 공지사항",
+                MaterialCategory.NOTICE,
+                null,
+                "공지 내용입니다.",
+                testStudy,
+                testUser
+        );
+
+        materialRepository.saveAll(Arrays.asList(learningMaterial1, learningMaterial2, noticeMaterial));
+    }
+
+    @Test
+    void 스터디ID로_자료_목록_최신순으로_조회() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        // when
+        Page<Material> result = materialRepository.findByStudyIdWithFiltersAndKeyword(
+                testStudy.getId(), null, null, null, pageable);
+        // then
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getContent()).extracting("title")
+                .containsExactly("중요 공지사항", "학습자료 2주차", "학습자료 1주차");
+    }
+
+    @Test
+    void 자료ID로_자료목록_조회() {
+        // given
+        List<Long> ids = Arrays.asList(learningMaterial1.getId(), noticeMaterial.getId());
+
+        // when
+        List<Material> result = materialRepository.findByIdIn(ids);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting("title")
+                .containsExactly("학습자료 1주차", "중요 공지사항");
+    }
+
+    @Test
+    void 카테고리_필터로_자료_조회_최신순() {
+        // given
+        List<MaterialCategory> categories = List.of(MaterialCategory.LEARNING);
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        // when
+        Page<Material> result = materialRepository.findByStudyIdWithFiltersAndKeyword(
+                testStudy.getId(), categories, null, null, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).extracting("materialCategory")
+                .containsOnly(MaterialCategory.LEARNING);
+    }
+
+    @Test
+    void 주차_필터로_자료_조회() {
+        // given
+        List<String> weeks = List.of("1");
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        // when
+        Page<Material> result = materialRepository.findByStudyIdWithFiltersAndKeyword(
+                testStudy.getId(), null, weeks, null, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).extracting("title")
+                .containsExactlyInAnyOrder("학습자료 1주차", "중요 공지사항");
+    }
+
+    @Test
+    void 키워드로_자료_검색() {
+        // given
+        String keyword = "공지";
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        // when
+        Page<Material> result = materialRepository.findByStudyIdWithFiltersAndKeyword(
+                testStudy.getId(), null, null, keyword, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().getFirst().getTitle()).contains("공지");
+    }
+
+    @Test
+    void 복합_필터로_자료_조회() {
+        // given
+        List<MaterialCategory> categories = List.of(MaterialCategory.LEARNING);
+        List<String> weeks = Arrays.asList("1", "2");
+        String keyword = "학습";
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        // when
+        Page<Material> result = materialRepository.findByStudyIdWithFiltersAndKeyword(
+                testStudy.getId(), categories, weeks, keyword, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).extracting("materialCategory")
+                .containsOnly(MaterialCategory.LEARNING);
+        assertThat(result.getContent()).extracting("title")
+                .allMatch(title -> ((String) title).contains("학습"));
+    }
+
+    @Test
+    void 존재하지_않는_스터디_ID로_목록_조회() {
+        // given
+        Long nonExistentStudyId = 999L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Material> result = materialRepository.findByStudyIdWithFiltersAndKeyword(
+                nonExistentStudyId, null, null, null, pageable);
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+    }
+
+    @Test
+    void 존재하지_않는_자료ID_목록으로_조회() {
+        // given
+        List<Long> nonExistentIds = Arrays.asList(999L, 1000L);
+
+        // when
+        List<Material> result = materialRepository.findByIdIn(nonExistentIds);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/pado/domain/material/service/MaterialServiceImplTest.java
+++ b/src/test/java/com/pado/domain/material/service/MaterialServiceImplTest.java
@@ -1,0 +1,345 @@
+package com.pado.domain.material.service;
+
+import com.pado.domain.material.dto.request.FileRequestDto;
+import com.pado.domain.material.dto.request.MaterialRequestDto;
+import com.pado.domain.material.dto.response.MaterialDetailResponseDto;
+import com.pado.domain.material.dto.response.MaterialListResponseDto;
+import com.pado.domain.material.entity.File;
+import com.pado.domain.material.entity.Material;
+import com.pado.domain.material.entity.MaterialCategory;
+import com.pado.domain.material.event.MaterialDeletedEvent;
+import com.pado.domain.material.repository.FileRepository;
+import com.pado.domain.material.repository.MaterialRepository;
+import com.pado.domain.s3.service.S3Service;
+import com.pado.domain.shared.entity.Region;
+import com.pado.domain.study.entity.Study;
+import com.pado.domain.study.repository.StudyMemberRepository;
+import com.pado.domain.study.repository.StudyRepository;
+import com.pado.domain.user.entity.User;
+import com.pado.domain.user.entity.Gender;
+import com.pado.global.exception.common.BusinessException;
+import com.pado.global.exception.common.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MaterialServiceImplTest {
+
+    @InjectMocks
+    private MaterialServiceImpl materialService;
+
+    @Mock
+    private MaterialRepository materialRepository;
+
+    @Mock
+    private FileRepository fileRepository;
+
+    @Mock
+    private StudyMemberRepository studyMemberRepository;
+
+    @Mock
+    private StudyRepository studyRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private User user;
+    private Study study;
+    private Material material;
+    private File file;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .email("test@example.com")
+                .nickname("testUser")
+                .passwordHash("password")
+                .gender(Gender.MALE)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        study = Study.builder()
+                .title("testStudy")
+                .description("Test Description")
+                .maxMembers(10)
+                .region(Region.SEOUL)
+                .leader(user)
+                .build();
+        ReflectionTestUtils.setField(study, "id", 1L);
+
+        material = new Material(
+                "Test Title",
+                MaterialCategory.LEARNING, 1,
+                "Test Content",
+                study,
+                user);
+        ReflectionTestUtils.setField(material, "id", 1L);
+
+        file = new File(
+                "Test File",
+                "File Key"
+        );
+        file.setMaterial(material);
+        ReflectionTestUtils.setField(file, "id", 1L);
+    }
+
+
+    @Test
+    void 자료생성_성공() {
+        // given
+        Long studyId = 1L;
+        MaterialRequestDto request = new MaterialRequestDto(
+                "Test Title",
+                MaterialCategory.LEARNING,
+                1,
+                "Test Content",
+                List.of(new FileRequestDto(null, "test.pdf", "test-key"))
+        );
+
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(true);
+        given(materialRepository.save(any(Material.class))).willReturn(material);
+        given(fileRepository.saveAll(anyList())).willReturn(Arrays.asList(file));
+        given(fileRepository.findByMaterialId(material.getId())).willReturn(Arrays.asList(file));
+
+        // when
+        MaterialDetailResponseDto result = materialService.createMaterial(user, studyId, request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isEqualTo("Test Title");
+        assertThat(result.category()).isEqualTo("학습자료");
+        assertThat(result.week()).isEqualTo(1);
+        assertThat(result.content()).isEqualTo("Test Content");
+        assertThat(result.files()).hasSize(1);
+
+        verify(materialRepository).save(any(Material.class));
+        verify(fileRepository).saveAll(anyList());
+    }
+
+    @Test
+    void 존재하지_않는_스터디로_인한_자료생성_실패() {
+        // given
+        Long studyId = 999L;
+        MaterialRequestDto request = new MaterialRequestDto(
+                "Test Title",
+                MaterialCategory.LEARNING,
+                1,
+                "Test Content",
+                Collections.emptyList()
+        );
+
+        given(studyRepository.findById(studyId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> materialService.createMaterial(user, studyId, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.STUDY_NOT_FOUND.message);
+    }
+
+    @Test
+    void 스터디원이_아님으로_인한_자료생성_실패() {
+        // given
+        Long studyId = 1L;
+        MaterialRequestDto request = new MaterialRequestDto(
+                "Test Title",
+                MaterialCategory.LEARNING,
+                1,
+                "Test Content",
+                Collections.emptyList()
+        );
+
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> materialService.createMaterial(user, studyId, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY.message);
+    }
+
+    @Test
+    void 자료_상세조회_성공() {
+        // given
+        Long materialId = 1L;
+
+        given(materialRepository.findById(materialId)).willReturn(Optional.of(material));
+        given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(true);
+        given(fileRepository.findByMaterialId(materialId)).willReturn(Arrays.asList(file));
+
+        // when
+        MaterialDetailResponseDto result = materialService.findMaterialById(user, materialId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(materialId);
+        assertThat(result.title()).isEqualTo("Test Title");
+        assertThat(result.files()).hasSize(1);
+    }
+
+    @Test
+    void 존재하지_않는_자료로_인한_상세조회_실패() {
+        // given
+        Long materialId = 999L;
+
+        given(materialRepository.findById(materialId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> materialService.findMaterialById(user, materialId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.MATERIAL_NOT_FOUND.message);
+    }
+
+    @Test
+    void 자료목록_조회_성공() {
+        // given
+        Long studyId = 1L;
+        List<String> categories = List.of("학습자료");
+        List<String> weeks = List.of("1");
+        String keyword = "File Key";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<Material> materialPage = new PageImpl<>(Arrays.asList(material), pageable, 1);
+
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(true);
+        given(materialRepository.findByStudyIdWithFiltersAndKeyword(
+                eq(studyId), anyList(), eq(weeks), eq(keyword), eq(pageable)))
+                .willReturn(materialPage);
+        given(fileRepository.findByMaterialIdIn(anyList())).willReturn(Arrays.asList(file));
+
+        // when
+        MaterialListResponseDto result = materialService.findAllMaterials(
+                user, studyId, categories, weeks, keyword, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.materials()).hasSize(1);
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    void 자료수정_성공() {
+        // given
+        Long materialId = 1L;
+        MaterialRequestDto request = new MaterialRequestDto(
+                "Updated Title",
+                MaterialCategory.NOTICE,
+                null,
+                "Updated Content",
+                Collections.emptyList()
+        );
+
+        given(materialRepository.findById(materialId)).willReturn(Optional.of(material));
+        given(materialRepository.save(any(Material.class))).willReturn(material);
+        given(fileRepository.findByMaterialId(materialId)).willReturn(Collections.emptyList());
+
+        // when
+        MaterialDetailResponseDto result = materialService.updateMaterial(user, materialId, request);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(materialRepository).save(any(Material.class));
+    }
+
+    @Test
+    void 작성자가_아님으로_인한_자료수정_실패() {
+        // given
+        Long materialId = 1L;
+        User otherUser = User.builder()
+                .email("test2@example.com")
+                .nickname("otherUser")
+                .passwordHash("password")
+                .gender(Gender.MALE)
+                .build();
+        MaterialRequestDto request = new MaterialRequestDto(
+                "Updated Title",
+                MaterialCategory.NOTICE,
+                null,
+                "Updated Content",
+                Collections.emptyList()
+        );
+
+        given(materialRepository.findById(materialId)).willReturn(Optional.of(material));
+
+        // when & then
+        assertThatThrownBy(() -> materialService.updateMaterial(otherUser, materialId, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.FORBIDDEN_MATERIAL_ACCESS.message);
+    }
+
+    @Test
+    void 자료삭제_성공() {
+        // given
+        List<Long> ids = List.of(1L);
+
+        given(materialRepository.findByIdIn(ids)).willReturn(Arrays.asList(material));
+        given(fileRepository.findByMaterialId(1L)).willReturn(Arrays.asList(file));
+
+        // when
+        materialService.deleteMaterial(user, ids);
+
+        // then
+        verify(fileRepository).deleteByMaterialId(1L);
+        verify(materialRepository).deleteAll(anyList());
+        verify(eventPublisher).publishEvent(any(MaterialDeletedEvent.class));
+    }
+
+    @Test
+    void 존재하지_않는_자료로_인한_삭제_실패() {
+        // given
+        List<Long> ids = Arrays.asList(1L, 2L);
+
+        given(materialRepository.findByIdIn(ids)).willReturn(Arrays.asList(material)); // 1개만 반환
+
+        // when & then
+        assertThatThrownBy(() -> materialService.deleteMaterial(user, ids))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.MATERIAL_NOT_FOUND.message);
+    }
+
+    @Test
+    void 작성자가_이님으로_인한_삭제_실패() {
+        // given
+        List<Long> ids = List.of(1L);
+        User otherUser = User.builder()
+                .email("test2@example.com")
+                .nickname("otherUser")
+                .passwordHash("password")
+                .gender(Gender.MALE)
+                .build();
+
+        given(materialRepository.findByIdIn(ids)).willReturn(Arrays.asList(material));
+
+        // when & then
+        assertThatThrownBy(() -> materialService.deleteMaterial(otherUser, ids))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.FORBIDDEN_MATERIAL_ACCESS.message);
+    }
+}


### PR DESCRIPTION
## ✨ 요약

구현된 유저, 스터디 도메인을 바탕으로 연관관계를 맺도록 구현 후, 테스트 코드까지 작성했습니다.

## 🔗 작업 내용

- 자료 엔티티에 유저, 스터디 연결 및 서비스 로직 수정
- 파일 테이블 이름 수정 및 `schema.sql`에 자료, 파일 테이블 생성하는 쿼리 작성
- 서비스, 레포지토리 단위 테스트 코드 작성
- JPA 자료 목록 조회를 DSL Query로 구현
- s3 버킷을 개발/운영 2개로 나눠 사용되도록 구현

## 💻 상세 구현 내용

- 구현된 유저와 스터디를 바탕으로 자료 엔티티에 연관관계를 맺은 후, 서비스 로직을 변경했습니다.
- `@CurrentUser` 사용하여 토큰에서 사용자를 추출해 서비스 로직에 사용할 수 있도록 했습니다.
- 파일 테이블의 이름을 기존 `file`에서 `material_file`로 수정했습니다.
- `schema.sql`에 자료, 파일 테이블 생성하는 쿼리 작성했습니다.
- 자료 서비스/레포지토리와 파일 레포지토리 단위 테스트 코드를 작성했습니다.
- 기존의 `@Query`를 통해 구현했던 자료목록조회 메서드를 DSL Query를 통해 구현하도록 수정했습니다.
- s3 버킷을 dev/prod 폴더로 나눠 개발용과 운영용을 구분하고 S3Service 로직을 수정했습니다.

## 🔗 참고 사항

> DSL Query와 S3 버킷의 경우 멘토님 피드백 반영한 것입니다. 원래 refactor 브랜치 만들어서 따로 작업했어야 했는데 까먹고 이 브랜치에 반영해버렸습니다.

## 📸 스크린샷 (Screenshots)
<img width="1416" height="1682" alt="image" src="https://github.com/user-attachments/assets/5974400a-2b09-4cb7-8bc3-8d2449b9f157" />
<img width="1399" height="1631" alt="image" src="https://github.com/user-attachments/assets/1161fb04-ff16-4c72-a581-9cb40127230d" />
이외의 다른 기능들도 정상작동하는 것을 확인했습니다.

## 🔗 관련 이슈

- Close #56 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)