### PR TITLE
feat: 출석 관련 CRUD 구현

### DIFF
--- a/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
@@ -4,6 +4,9 @@ import com.pado.domain.attendance.dto.AttendanceListResponseDto;
 import com.pado.domain.attendance.dto.AttendanceStatusDto;
 import com.pado.domain.attendance.dto.AttendanceStatusResponseDto;
 import com.pado.domain.attendance.dto.MemberAttendanceDto;
+import com.pado.domain.attendance.service.AttendanceService;
+import com.pado.domain.user.entity.User;
+import com.pado.global.auth.annotation.CurrentUser;
 import com.pado.global.exception.dto.ErrorResponseDto;
 import com.pado.global.swagger.annotation.study.Api403ForbiddenStudyMemberOnlyError;
 import com.pado.global.swagger.annotation.schedule.Api404ScheduleNotFoundError;
@@ -30,8 +33,7 @@ import java.util.List;
 @RequestMapping("/api")
 @RequiredArgsConstructor
 public class AttendanceController {
-
-    // TODO: 서비스 레이어 종속성 주입
+    private final AttendanceService attendanceService;
 
     @Api403ForbiddenStudyMemberOnlyError
     @Api404StudyNotFoundError
@@ -133,9 +135,9 @@ public class AttendanceController {
     })
     @PostMapping("/schedules/{schedule_id}/attendance")
     public ResponseEntity<AttendanceStatusResponseDto> checkAttendance(
-            @PathVariable("schedule_id") Long scheduleId
+            @PathVariable("schedule_id") Long scheduleId,
+            @Parameter(hidden = true) @CurrentUser User user
     ) {
-        // TODO: 출석 체크 로직 구현
-        return ResponseEntity.ok(new AttendanceStatusResponseDto(true));
+        return ResponseEntity.ok(attendanceService.checkIn(scheduleId, user));
     }
 }

--- a/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
@@ -92,13 +92,10 @@ public class AttendanceController {
     @GetMapping("/studies/{study_id}/attendance/{schedule_id}")
     public ResponseEntity<AttendanceStatusResponseDto> getIndividualAttendanceStatus(
             @PathVariable("study_id") Long studyId,
-            @PathVariable("schedule_id") Long scheduleId
+            @PathVariable("schedule_id") Long scheduleId,
+            @CurrentUser User user
     ) {
-        // TODO: 개별 참여 현황 조회 로직 구현
-        boolean hasAttended = true;
-        AttendanceStatusResponseDto mockResponse = new AttendanceStatusResponseDto(hasAttended);
-
-        return ResponseEntity.ok(mockResponse);
+        return ResponseEntity.ok(attendanceService.getIndividualAttendanceStatus(studyId, scheduleId, user));
     }
 
     @Api403ForbiddenStudyMemberOnlyError

--- a/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
@@ -52,27 +52,7 @@ public class AttendanceController {
     public ResponseEntity<AttendanceListResponseDto> getFullAttendance(
             @PathVariable("study_id") Long studyId
     ) {
-        // TODO: 전체 참여 현황 조회 로직 구현
-        List<MemberAttendanceDto> mockMembers = Arrays.asList(
-                new MemberAttendanceDto(
-                        "리더유저",
-                        "https://pado-image.com/user/1",
-                        List.of(
-                                new AttendanceStatusDto(true, LocalDateTime.of(2025, 9, 1, 10, 0)),
-                                new AttendanceStatusDto(false, LocalDateTime.of(2025, 9, 8, 10, 0))
-                        )
-                ),
-                new MemberAttendanceDto(
-                        "참여자1",
-                        "https://pado-image.com/user/2",
-                        List.of(
-                                new AttendanceStatusDto(true, LocalDateTime.of(2025, 9, 1, 10, 0)),
-                                new AttendanceStatusDto(true, LocalDateTime.of(2025, 9, 8, 10, 0))
-                        )
-                )
-        );
-        AttendanceListResponseDto mockResponse = new AttendanceListResponseDto(mockMembers);
-        return ResponseEntity.ok(mockResponse);
+        return ResponseEntity.ok(attendanceService.getFullAttendance(studyId));
     }
 
     @Api403ForbiddenStudyMemberOnlyError
@@ -93,7 +73,7 @@ public class AttendanceController {
     public ResponseEntity<AttendanceStatusResponseDto> getIndividualAttendanceStatus(
             @PathVariable("study_id") Long studyId,
             @PathVariable("schedule_id") Long scheduleId,
-            @CurrentUser User user
+            @Parameter(hidden = true) @CurrentUser User user
     ) {
         return ResponseEntity.ok(attendanceService.getIndividualAttendanceStatus(studyId, scheduleId, user));
     }

--- a/src/main/java/com/pado/domain/attendance/entity/Attendance.java
+++ b/src/main/java/com/pado/domain/attendance/entity/Attendance.java
@@ -1,0 +1,57 @@
+package com.pado.domain.attendance.entity;
+
+import com.pado.domain.schedule.entity.Schedule;
+import com.pado.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "attendance")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Attendance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id", nullable = false)
+    private Schedule schedule;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "status", nullable = false)
+    private boolean status;
+
+    @Column(name = "check_in_time")
+    private LocalDateTime checkInTime;
+
+    @Builder
+    public Attendance(Schedule schedule, User user, boolean status, LocalDateTime checkInTime) {
+        this.schedule = schedule;
+        this.user = user;
+        this.status = status;
+        this.checkInTime = checkInTime;
+    }
+
+    public static Attendance createCheckIn(Schedule schedule, User user) {
+        return Attendance.builder()
+                .schedule(schedule)
+                .user(user)
+                .status(true)
+                .checkInTime(LocalDateTime.now())
+                .build();
+    }
+}
+

--- a/src/main/java/com/pado/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/com/pado/domain/attendance/repository/AttendanceRepository.java
@@ -6,6 +6,8 @@ import com.pado.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     boolean existsByScheduleAndUser(Schedule schedule, User user);

--- a/src/main/java/com/pado/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/com/pado/domain/attendance/repository/AttendanceRepository.java
@@ -4,11 +4,22 @@ import com.pado.domain.attendance.entity.Attendance;
 import com.pado.domain.schedule.entity.Schedule;
 import com.pado.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     boolean existsByScheduleAndUser(Schedule schedule, User user);
+
+    @Query("""
+        select a
+        from Attendance a
+        join fetch a.schedule s
+        join fetch a.user u
+        where s.studyId = :studyId
+    """)
+    List<Attendance> findAllByStudyIdWithScheduleAndUser(@Param("studyId") Long studyId);
 }

--- a/src/main/java/com/pado/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/com/pado/domain/attendance/repository/AttendanceRepository.java
@@ -1,0 +1,12 @@
+package com.pado.domain.attendance.repository;
+
+import com.pado.domain.attendance.entity.Attendance;
+import com.pado.domain.schedule.entity.Schedule;
+import com.pado.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+    boolean existsByScheduleAndUser(Schedule schedule, User user);
+}

--- a/src/main/java/com/pado/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/pado/domain/attendance/service/AttendanceService.java
@@ -1,11 +1,15 @@
 package com.pado.domain.attendance.service;
 
 
+import com.pado.domain.attendance.dto.AttendanceListResponseDto;
 import com.pado.domain.attendance.dto.AttendanceStatusResponseDto;
 import com.pado.domain.user.entity.User;
 
 public interface AttendanceService {
-    AttendanceStatusResponseDto checkIn(Long ScheduleId, User user);
-
+    // 전체 참여 현황 조회
+    AttendanceListResponseDto getFullAttendance(Long studyId);
+    // 개별 참여 현황 조회
     AttendanceStatusResponseDto getIndividualAttendanceStatus(Long studyId, Long scheduleId,  User user);
+    // 출석
+    AttendanceStatusResponseDto checkIn(Long ScheduleId, User user);
 }

--- a/src/main/java/com/pado/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/pado/domain/attendance/service/AttendanceService.java
@@ -6,4 +6,6 @@ import com.pado.domain.user.entity.User;
 
 public interface AttendanceService {
     AttendanceStatusResponseDto checkIn(Long ScheduleId, User user);
+
+    AttendanceStatusResponseDto getIndividualAttendanceStatus(Long studyId, Long scheduleId,  User user);
 }

--- a/src/main/java/com/pado/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/pado/domain/attendance/service/AttendanceService.java
@@ -1,0 +1,9 @@
+package com.pado.domain.attendance.service;
+
+
+import com.pado.domain.attendance.dto.AttendanceStatusResponseDto;
+import com.pado.domain.user.entity.User;
+
+public interface AttendanceService {
+    AttendanceStatusResponseDto checkIn(Long ScheduleId, User user);
+}

--- a/src/main/java/com/pado/domain/attendance/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/pado/domain/attendance/service/AttendanceServiceImpl.java
@@ -1,0 +1,50 @@
+package com.pado.domain.attendance.service;
+
+import com.pado.domain.attendance.dto.AttendanceStatusResponseDto;
+import com.pado.domain.attendance.entity.Attendance;
+import com.pado.domain.attendance.repository.AttendanceRepository;
+import com.pado.domain.schedule.entity.Schedule;
+import com.pado.domain.schedule.repository.ScheduleRepository;
+import com.pado.domain.study.entity.Study;
+import com.pado.domain.study.repository.StudyMemberRepository;
+import com.pado.domain.study.repository.StudyRepository;
+import com.pado.domain.user.entity.User;
+import com.pado.global.exception.common.BusinessException;
+import com.pado.global.exception.common.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceServiceImpl implements AttendanceService {
+    private final AttendanceRepository attendanceRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final StudyMemberRepository studyMemberRepository;
+    private final StudyRepository studyRepository;
+
+    @Override
+    public AttendanceStatusResponseDto checkIn(Long scheduleId, User user) {
+        //스케줄 검증
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND));
+
+        // 스터디 검증
+        Study study = studyRepository.findById(schedule.getStudyId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
+
+        // 스터디 멤버 검증
+        if (!studyMemberRepository.existsByStudyAndUser(study, user)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY);
+        }
+
+        // 출석 여부 확인
+        if(attendanceRepository.existsByScheduleAndUser(schedule, user)) {
+            throw new BusinessException(ErrorCode.ALREADY_CHECKED_IN);
+        }
+
+        Attendance attendance = Attendance.createCheckIn(schedule, user);
+        attendanceRepository.save(attendance);
+
+        return new AttendanceStatusResponseDto(true);
+    }
+}

--- a/src/main/java/com/pado/domain/attendance/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/pado/domain/attendance/service/AttendanceServiceImpl.java
@@ -1,11 +1,16 @@
 package com.pado.domain.attendance.service;
 
+import com.pado.domain.attendance.dto.AttendanceListResponseDto;
+import com.pado.domain.attendance.dto.AttendanceStatusDto;
 import com.pado.domain.attendance.dto.AttendanceStatusResponseDto;
+import com.pado.domain.attendance.dto.MemberAttendanceDto;
 import com.pado.domain.attendance.entity.Attendance;
 import com.pado.domain.attendance.repository.AttendanceRepository;
 import com.pado.domain.schedule.entity.Schedule;
 import com.pado.domain.schedule.repository.ScheduleRepository;
 import com.pado.domain.study.entity.Study;
+import com.pado.domain.study.entity.StudyMember;
+import com.pado.domain.study.entity.StudyMemberRole;
 import com.pado.domain.study.repository.StudyMemberRepository;
 import com.pado.domain.study.repository.StudyRepository;
 import com.pado.domain.user.entity.User;
@@ -13,6 +18,11 @@ import com.pado.global.exception.common.BusinessException;
 import com.pado.global.exception.common.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,10 +33,51 @@ public class AttendanceServiceImpl implements AttendanceService {
     private final StudyRepository studyRepository;
 
     @Override
+    @Transactional(readOnly = true)
+    public AttendanceListResponseDto getFullAttendance(Long studyId) {
+        Study study = studyRepository.findById(studyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
+        Long leaderId = studyMemberRepository.findLeaderUserIdByStudy(study, StudyMemberRole.LEADER);
+        List<StudyMember> studyMembers = studyMemberRepository.findByStudyWithUser(study);
+        List<Schedule> schedules = scheduleRepository.findByStudyIdOrderByStartTimeAsc(studyId);
+        List<Attendance> attendances = attendanceRepository.findAllByStudyIdWithScheduleAndUser(studyId);
+        List<StudyMember> orderedMembers = studyMembers.stream()
+                .sorted(Comparator.comparing(sm -> !sm.getUser().getId().equals(leaderId)))
+                .toList();
+
+        Map<String, Attendance> attendanceMap = attendances.stream()
+                .collect(Collectors.toMap(
+                        attendance -> attendance.getUser().getId()+ "-" +  attendance.getSchedule().getId(),
+                        attendance -> attendance
+                ));
+
+        // MemberAttendanceDto List 생성
+        List<MemberAttendanceDto> memberAttendanceDtoList = orderedMembers.stream()
+                .map(studyMember -> {
+                    User user = studyMember.getUser();
+
+                    //AttendanceStatusDto List 생성
+                    List<AttendanceStatusDto> attendanceStatusDtoList = schedules.stream()
+                            .map(schedule -> {
+                                Attendance attendance = attendanceMap.get(user.getId() + "-" + schedule.getId());
+                                boolean status = (attendance != null) && (attendance.isStatus());
+                                return new AttendanceStatusDto(status, schedule.getStartTime());
+                            })
+                            .toList();
+                    return new MemberAttendanceDto(user.getNickname(), user.getProfileImageUrl(), attendanceStatusDtoList);
+                })
+                .toList();
+
+        return new AttendanceListResponseDto(memberAttendanceDtoList);
+    }
+
+
+    @Override
     public AttendanceStatusResponseDto getIndividualAttendanceStatus(Long studyId, Long scheduleId, User user) {
         Schedule schedule = checkException(scheduleId, user);
         return new AttendanceStatusResponseDto(attendanceRepository.existsByScheduleAndUser(schedule, user));
     }
+
 
     @Override
     public AttendanceStatusResponseDto checkIn(Long scheduleId, User user) {
@@ -43,6 +94,7 @@ public class AttendanceServiceImpl implements AttendanceService {
         return new AttendanceStatusResponseDto(true);
     }
 
+    // 공통 예외 검증
     private Schedule checkException(Long scheduleId, User user){
         // 스케줄 검증
         Schedule schedule = scheduleRepository.findById(scheduleId)

--- a/src/main/java/com/pado/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/pado/domain/schedule/repository/ScheduleRepository.java
@@ -1,7 +1,6 @@
 package com.pado.domain.schedule.repository;
 
 import com.pado.domain.schedule.entity.Schedule;
-import com.pado.domain.study.entity.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,6 +8,6 @@ import java.util.List;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
-
     List<Schedule> findAllByStudyId(Long studyId);
+    List<Schedule> findByStudyIdOrderByStartTimeAsc(Long studyId);
 }

--- a/src/main/java/com/pado/domain/study/repository/StudyMemberRepository.java
+++ b/src/main/java/com/pado/domain/study/repository/StudyMemberRepository.java
@@ -2,10 +2,31 @@ package com.pado.domain.study.repository;
 
 import com.pado.domain.study.entity.Study;
 import com.pado.domain.study.entity.StudyMember;
+import com.pado.domain.study.entity.StudyMemberRole;
 import com.pado.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
     long countByStudy(Study study);
     boolean existsByStudyAndUser(Study study, User user);
+
+    @Query("""
+        select sm
+        from StudyMember sm
+        join fetch sm.user u
+        where sm.study = :study
+    """)
+    List<StudyMember> findByStudyWithUser(@Param("study") Study study);
+
+    @Query("""
+        select u.id
+        from StudyMember sm
+        join sm.user u
+        where sm.role = :role and sm.study = :study
+    """)
+    Long findLeaderUserIdByStudy(@Param("study") Study study, @Param("role") StudyMemberRole role);
 }

--- a/src/test/java/com/pado/domain/attendance/service/AttendanceServiceImplTest.java
+++ b/src/test/java/com/pado/domain/attendance/service/AttendanceServiceImplTest.java
@@ -1,0 +1,196 @@
+package com.pado.domain.attendance.service;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import com.pado.domain.attendance.dto.AttendanceStatusResponseDto;
+import com.pado.domain.attendance.entity.Attendance;
+import com.pado.domain.attendance.repository.AttendanceRepository;
+import com.pado.domain.schedule.entity.Schedule;
+import com.pado.domain.schedule.repository.ScheduleRepository;
+import com.pado.domain.shared.entity.Region;
+import com.pado.domain.study.entity.Study;
+import com.pado.domain.study.repository.StudyMemberRepository;
+import com.pado.domain.study.repository.StudyRepository;
+import com.pado.domain.user.entity.Gender;
+import com.pado.domain.user.entity.User;
+import com.pado.global.exception.common.BusinessException;
+import com.pado.global.exception.common.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AttendanceServiceImplTest {
+
+    @InjectMocks
+    private AttendanceServiceImpl attendanceService;
+
+    @Mock
+    private AttendanceRepository attendanceRepository;
+    @Mock
+    private ScheduleRepository scheduleRepository;
+    @Mock
+    private StudyRepository studyRepository;
+    @Mock
+    private StudyMemberRepository studyMemberRepository;
+
+    @Test
+    @DisplayName("출석 성공")
+    void 출석_성공_여부() {
+        User user = User.builder()
+                .email("test@test.com")
+                .passwordHash("hashed")
+                .nickname("tester")
+                .region(Region.SEOUL)
+                .gender(Gender.MALE)
+                .build();
+
+        ReflectionTestUtils.setField(user, "id", 10L);
+
+        Schedule schedule = Schedule.builder()
+                .studyId(100L)
+                .title("스터디 일정")
+                .description("스터디 설명")
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now().plusHours(2))
+                .build();
+
+        Study study = Study.builder().id(100L).build();
+
+        given(scheduleRepository.findById(schedule.getId())).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(100L)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(true);
+        given(attendanceRepository.existsByScheduleAndUser(schedule, user)).willReturn(false);
+
+        // when
+        AttendanceStatusResponseDto response = attendanceService.checkIn(schedule.getId(), user);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.status()).isTrue();
+        verify(attendanceRepository, times(1)).save(any(Attendance.class));
+    }
+
+    @Test
+    @DisplayName("스케줄이 없으면 예외 발생")
+    void 스케줄_없을_때_예외() {
+        Long scheduleId = 1L;
+        User user = User.builder()
+                .email("test@test.com")
+                .passwordHash("hashed")
+                .nickname("tester")
+                .region(Region.SEOUL)
+                .gender(Gender.MALE)
+                .build();
+
+        ReflectionTestUtils.setField(user, "id", 10L);
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.SCHEDULE_NOT_FOUND.message);
+    }
+
+    @Test
+    @DisplayName("스터디가 없으면 예외 발생")
+    void 스터디_없을_때_예외() {
+        // given
+        Long scheduleId = 1L;
+        User user = User.builder()
+                .email("test@test.com")
+                .passwordHash("hashed")
+                .nickname("tester")
+                .region(Region.SEOUL)
+                .gender(Gender.MALE)
+                .build();
+
+        ReflectionTestUtils.setField(user, "id", 10L);
+
+        Schedule schedule = Schedule.builder()
+                .studyId(100L)
+                .title("스터디 일정")
+                .description("스터디 설명")
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now().plusHours(2))
+                .build();
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(100L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.STUDY_NOT_FOUND.message);
+    }
+
+    @Test
+    @DisplayName("스터디 멤버가 아니면 예외 발생")
+    void 스터디_맴버_아닐_때_예외() {
+        // given
+        Long scheduleId = 1L;
+        User user = User.builder()
+                .email("test@test.com")
+                .passwordHash("hashed")
+                .nickname("tester")
+                .region(Region.SEOUL)
+                .gender(Gender.MALE)
+                .build();
+
+        ReflectionTestUtils.setField(user, "id", 10L);
+
+        Schedule schedule = Schedule.builder().studyId(100L).build();
+        Study study = Study.builder().id(100L).build();
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(100L)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY.message);
+    }
+
+    @Test
+    @DisplayName("이미 출석한 경우 예외 발생")
+    void 이미_출석했을_때_예외() {
+        // given
+        Long scheduleId = 1L;
+        User user = User.builder()
+                .email("test@test.com")
+                .passwordHash("hashed")
+                .nickname("tester")
+                .region(Region.SEOUL)
+                .gender(Gender.MALE)
+                .build();
+
+        ReflectionTestUtils.setField(user, "id", 10L);
+
+        Schedule schedule = Schedule.builder().studyId(100L).build();
+        Study study = Study.builder().id(100L).build();
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(100L)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(true);
+        given(attendanceRepository.existsByScheduleAndUser(schedule, user)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.ALREADY_CHECKED_IN.message);
+    }
+}


### PR DESCRIPTION
## ✨ 요약

> 스터디 출석 관리 CRUD 구현하였습니다.

## 🔗 작업 내용

- Attendance 엔티티 생성 및 Schedule, User 연관관계 매핑
- AttendanceRepository 추가
- AttendanceService / AttendanceServiceImpl에 checkIn, getIndividualAttendanceStatus, getFullAttendance 메서드 구현

- AttendanceController에 출석 관련 API 추가
  - GET /studies/{studyId}/attendance : 전체 출석 현황 조회
  - GET /studies/{studyId}/attendance/{scheduleId} : 개별 출석 여부 확인
  - POST /schedules/{scheduleId}/attendance : 출석 체크

- Attendance 단위 테스트 작성
  - 출석 체크 성공/예외 케이스 검증
  - 개별 출석 여부 확인 (출석/미출석) 검증
  - 전체 출석 현황 조회 (스케줄별, 멤버별, 리더 우선 정렬) 검증
  
## 💻 상세 구현 내용

- **Attendance 엔티티**
  - Schedule, User와 다대일 연관관계 설정
  - 정적 팩토리 메서드 `createCheckIn` 제공

- **Repository**
  - existsByScheduleAndUser로 개별 출석 여부 확인
  - findAllByStudyIdWithScheduleAndUser 로 전체 출석 조회
  - findLeaderUserIdByStudy 로 리더 ID 조회

- **Service**
  - checkIn: 이미 출석한 경우 예외 발생, 아니면 출석 저장
  - getIndividualAttendanceStatus: 특정 스케줄 기준 개별 출석 여부 반환
  - getFullAttendance: 스터디 전체 출석 현황 조회, 스케줄 시간순 정렬 및 리더 우선 정렬 적용

- **Controller**
  - 출석 체크, 개별 출석 여부 확인, 전체 출석 현황 조회 API 제공

- **Test**
  - Service 단위 테스트에서 정상 동작 및 예외 케이스 검증
  - 리더가 항상 첫 번째로 노출되는지 검증
  - 스케줄 정렬 및 출석 매핑 결과 검증

## 🔗 참고 사항

> 개별참여 현황 조회(getIndividualAttendanceStatus)에서 schedule 과 study는 독립적이라 studyId를 안 받아도 될것 같습니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #60

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)