### PR TITLE
feat: 파일 엔티티에 파일 타입을 필드 추가

### DIFF
--- a/src/main/java/com/pado/domain/material/dto/request/FileRequestDto.java
+++ b/src/main/java/com/pado/domain/material/dto/request/FileRequestDto.java
@@ -1,5 +1,6 @@
 package com.pado.domain.material.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -22,5 +23,9 @@ public record FileRequestDto(
 
         @Schema(description = "파일 크기(단위: bytes)", example = "1024")
         @NotNull(message = "파일 크기는 필수입니다.")
-        Long size
+        Long size,
+
+        @JsonProperty("file_type")
+        @Schema(name = "file_type", description = "파일 타입", example = ".pdf")
+        String fileType
 ) {}

--- a/src/main/java/com/pado/domain/material/dto/request/MaterialRequestDto.java
+++ b/src/main/java/com/pado/domain/material/dto/request/MaterialRequestDto.java
@@ -41,8 +41,8 @@ public record MaterialRequestDto(
                 """,
                 example = """
                 [
-                  {"id": 1, "name": "기존파일.pdf", "key": "..."},
-                  {"id": null, "name": "새파일.jpg", "key": "..."}
+                  {"id": 1, "name": "기존파일.pdf", "key": "...", "size": 795820, "file_type": ".pdf"},
+                  {"id": null, "name": "새파일.jpg", "key": "...", "size": 500000, "file_type": ".pptx"}
                 ]
                 """)
         @NotNull(message = "files는 null일 수 없습니다.")

--- a/src/main/java/com/pado/domain/material/dto/response/FileResponseDto.java
+++ b/src/main/java/com/pado/domain/material/dto/response/FileResponseDto.java
@@ -14,6 +14,10 @@ public record FileResponseDto(
         String key,
 
         @Schema(description = "파일 크기 (단위: bytes)", example = "1024")
-        Long size
+        Long size,
+
+        @Schema(description = "파일 타입", example = ".pdf")
+        @JsonProperty("file_type")
+        String fileType
 ) {
 }

--- a/src/main/java/com/pado/domain/material/entity/File.java
+++ b/src/main/java/com/pado/domain/material/entity/File.java
@@ -25,15 +25,19 @@ public class File {
     @Column(nullable = false)
     private Long size; // 단위: byte
 
+    @Column(name = "file_type", nullable = false)
+    private String fileType;
+
     // Material 생성 이후 setter를 통해 연관관계를 지어줘야 함
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "material_id", nullable = false)
     private Material material;
 
-    public File(String name, String fileKey, Long size) {
+    public File(String name, String fileKey, Long size, String fileType) {
         this.name = name;
         this.fileKey = fileKey;
         this.size = size;
+        this.fileType = fileType;
     }
 }

--- a/src/main/java/com/pado/domain/material/service/MaterialServiceImpl.java
+++ b/src/main/java/com/pado/domain/material/service/MaterialServiceImpl.java
@@ -202,7 +202,7 @@ public class MaterialServiceImpl implements MaterialService {
 
     // 파일 엔티티 생성 메서드
     private File createFileEntity(FileRequestDto fileDto, Material material) {
-        File file = new File(fileDto.name(), fileDto.key(), fileDto.size());
+        File file = new File(fileDto.name(), fileDto.key(), fileDto.size(), fileDto.fileType());
         file.setMaterial(material);
         return file;
     }
@@ -266,7 +266,7 @@ public class MaterialServiceImpl implements MaterialService {
     private MaterialDetailResponseDto convertToDetailResponseDto(Material material) {
         List<File> files = fileRepository.findByMaterialId(material.getId());
         List<FileResponseDto> fileResponseDtos = files.stream()
-                .map(file -> new FileResponseDto(file.getId(), file.getName(), file.getFileKey(), file.getSize()))
+                .map(file -> new FileResponseDto(file.getId(), file.getName(), file.getFileKey(), file.getSize(), file.getFileType()))
                 .collect(Collectors.toList());
 
         return new MaterialDetailResponseDto(

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -127,6 +127,7 @@ CREATE TABLE material_file (
     name VARCHAR(255) NOT NULL,
     file_key VARCHAR(255) NOT NULL UNIQUE,
     size BIGINT NOT NULL,
+    file_type VARCHAR(50) NOT NULL,
     material_id BIGINT NOT NULL,
     CONSTRAINT fk_material_file_material FOREIGN KEY (material_id) REFERENCES material (id) ON DELETE CASCADE
 


### PR DESCRIPTION
## ✨ 요약

추후 퀴즈 생성에 앞서 파일의 타입을 알기 위한 타입 필드를 추가했습니다.

## 🔗 작업 내용

- 파일 엔티티에 파일타입 추가
- dto, service 로직 수정
- schema에 파일 테이블에서 파일 타입 추가

## 💻 상세 구현 내용

- 파일 엔티티에 파일의 타입을 저정할 수 있는 필드를 추가했습니다. (ex. .pdf, .pptx 등)
- 파일 응답/요청 dto에 파일타입 추가 및 이에 따른 자료 서비스 로직을 변경했습니다.
- schema.sql의 파일 테이블에서 파일 타입 컬럼을 추가했습니다.
- 자료 요청 dto의 스웨거 설명 파트에서 추가된 필드에 대한 설명을 추가했습니다.

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #77 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)