### PR TITLE
refactor: 일정·조율·출석 API 경로 수정

### DIFF
--- a/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
@@ -33,24 +33,25 @@ import java.util.List;
 @RequestMapping("/api")
 @RequiredArgsConstructor
 public class AttendanceController {
+
     private final AttendanceService attendanceService;
 
     @Api403ForbiddenStudyMemberOnlyError
     @Api404StudyNotFoundError
     @Operation(
-            summary = "전체 참여 현황 조회",
-            description = "지금까지 진행한 스터디의 전체 참여 현황을 조회합니다. (스터디 멤버만 가능)"
+        summary = "전체 참여 현황 조회",
+        description = "지금까지 진행한 스터디의 전체 참여 현황을 조회합니다. (스터디 멤버만 가능)"
     )
     @ApiResponse(
-            responseCode = "200", description = "전체 참여 현황 조회 성공",
-            content = @Content(schema = @Schema(implementation = AttendanceListResponseDto.class))
+        responseCode = "200", description = "전체 참여 현황 조회 성공",
+        content = @Content(schema = @Schema(implementation = AttendanceListResponseDto.class))
     )
     @Parameters({
-            @Parameter(name = "study_id", description = "참여 현황을 조회할 스터디의 ID", required = true, example = "1")
+        @Parameter(name = "study_id", description = "참여 현황을 조회할 스터디의 ID", required = true, example = "1")
     })
     @GetMapping("/studies/{study_id}/attendance")
     public ResponseEntity<AttendanceListResponseDto> getFullAttendance(
-            @PathVariable("study_id") Long studyId
+        @PathVariable("study_id") Long studyId
     ) {
         return ResponseEntity.ok(attendanceService.getFullAttendance(studyId));
     }
@@ -58,62 +59,61 @@ public class AttendanceController {
     @Api403ForbiddenStudyMemberOnlyError
     @Api404ScheduleNotFoundError
     @Operation(
-            summary = "개별 참여 현황 조회",
-            description = "사용자의 특정 스터디 일정에 대한 참여 현황을 조회합니다. (스터디 멤버만 가능)"
+        summary = "개별 참여 현황 조회",
+        description = "사용자의 특정 스터디 일정에 대한 참여 현황을 조회합니다. (스터디 멤버만 가능)"
     )
     @ApiResponse(
-            responseCode = "200", description = "개별 참여 현황 조회 성공",
-            content = @Content(schema = @Schema(implementation = AttendanceStatusResponseDto.class))
+        responseCode = "200", description = "개별 참여 현황 조회 성공",
+        content = @Content(schema = @Schema(implementation = AttendanceStatusResponseDto.class))
     )
     @Parameters({
-            @Parameter(name = "study_id", description = "조회할 스터디의 ID", required = true, example = "1"),
-            @Parameter(name = "schedule_id", description = "출석 상태를 조회할 일정의 ID", required = true, example = "1234")
+        @Parameter(name = "study_id", description = "조회할 스터디의 ID", required = true, example = "1"),
+        @Parameter(name = "schedule_id", description = "출석 상태를 조회할 일정의 ID", required = true, example = "1234")
     })
-    @GetMapping("/studies/{study_id}/attendance/{schedule_id}")
+    @GetMapping("schedules/{scheduleid}/attendance")
     public ResponseEntity<AttendanceStatusResponseDto> getIndividualAttendanceStatus(
-            @PathVariable("study_id") Long studyId,
-            @PathVariable("schedule_id") Long scheduleId,
-            @Parameter(hidden = true) @CurrentUser User user
+        @PathVariable("scheduleid") Long scheduleId,
+        @Parameter(hidden = true) @CurrentUser User user
     ) {
-        return ResponseEntity.ok(attendanceService.getIndividualAttendanceStatus(studyId, scheduleId, user));
+        return ResponseEntity.ok(attendanceService.getIndividualAttendanceStatus(scheduleId, user));
     }
 
     @Api403ForbiddenStudyMemberOnlyError
     @Api404ScheduleNotFoundError
     @Operation(
-            summary = "출석 체크",
-            description = "스터디원이 자신의 출석을 체크합니다."
+        summary = "출석 체크",
+        description = "스터디원이 자신의 출석을 체크합니다."
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "출석 체크 성공",
-                    content = @Content(schema = @Schema(implementation = AttendanceStatusResponseDto.class))),
-            @ApiResponse(responseCode = "409", description = "출석 시간 만료 또는 이미 출석 체크됨",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponseDto.class),
-                            examples = {
-                                    @ExampleObject(
-                                            name = "이미 출석 체크됨 예시",
-                                            value = """
-                                                {
-                                                  "code": "ALREADY_CHECKED_IN",
-                                                  "message": "이미 출석 체크되었습니다.",
-                                                  "errors": [],
-                                                  "timestamp": "2025-09-07T08:15:10.8668626",
-                                                  "path": "/api/schedules/1234/attendance"
-                                                }
-                                                """
-                                    )
-                            })
-            )
+        @ApiResponse(responseCode = "200", description = "출석 체크 성공",
+            content = @Content(schema = @Schema(implementation = AttendanceStatusResponseDto.class))),
+        @ApiResponse(responseCode = "409", description = "출석 시간 만료 또는 이미 출석 체크됨",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponseDto.class),
+                examples = {
+                    @ExampleObject(
+                        name = "이미 출석 체크됨 예시",
+                        value = """
+                            {
+                              "code": "ALREADY_CHECKED_IN",
+                              "message": "이미 출석 체크되었습니다.",
+                              "errors": [],
+                              "timestamp": "2025-09-07T08:15:10.8668626",
+                              "path": "/api/schedules/1234/attendance"
+                            }
+                            """
+                    )
+                })
+        )
     })
     @Parameters({
-            @Parameter(name = "schedule_id", description = "출석 체크할 일정의 ID", required = true, example = "1234")
+        @Parameter(name = "schedule_id", description = "출석 체크할 일정의 ID", required = true, example = "1234")
     })
     @PostMapping("/schedules/{schedule_id}/attendance")
     public ResponseEntity<AttendanceStatusResponseDto> checkAttendance(
-            @PathVariable("schedule_id") Long scheduleId,
-            @Parameter(hidden = true) @CurrentUser User user
+        @PathVariable("schedule_id") Long scheduleId,
+        @Parameter(hidden = true) @CurrentUser User user
     ) {
         return ResponseEntity.ok(attendanceService.checkIn(scheduleId, user));
     }

--- a/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
@@ -67,7 +67,6 @@ public class AttendanceController {
         content = @Content(schema = @Schema(implementation = AttendanceStatusResponseDto.class))
     )
     @Parameters({
-        @Parameter(name = "study_id", description = "조회할 스터디의 ID", required = true, example = "1"),
         @Parameter(name = "schedule_id", description = "출석 상태를 조회할 일정의 ID", required = true, example = "1234")
     })
     @GetMapping("schedules/{scheduleid}/attendance")

--- a/src/main/java/com/pado/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/pado/domain/attendance/service/AttendanceService.java
@@ -6,10 +6,13 @@ import com.pado.domain.attendance.dto.AttendanceStatusResponseDto;
 import com.pado.domain.user.entity.User;
 
 public interface AttendanceService {
+
     // 전체 참여 현황 조회
     AttendanceListResponseDto getFullAttendance(Long studyId);
+
     // 개별 참여 현황 조회
-    AttendanceStatusResponseDto getIndividualAttendanceStatus(Long studyId, Long scheduleId,  User user);
+    AttendanceStatusResponseDto getIndividualAttendanceStatus(Long scheduleId, User user);
+
     // 출석
     AttendanceStatusResponseDto checkIn(Long ScheduleId, User user);
 }

--- a/src/main/java/com/pado/domain/attendance/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/pado/domain/attendance/service/AttendanceServiceImpl.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class AttendanceServiceImpl implements AttendanceService {
+
     private final AttendanceRepository attendanceRepository;
     private final ScheduleRepository scheduleRepository;
     private final StudyMemberRepository studyMemberRepository;
@@ -36,46 +37,51 @@ public class AttendanceServiceImpl implements AttendanceService {
     @Transactional(readOnly = true)
     public AttendanceListResponseDto getFullAttendance(Long studyId) {
         Study study = studyRepository.findById(studyId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
-        Long leaderId = studyMemberRepository.findLeaderUserIdByStudy(study, StudyMemberRole.LEADER);
+            .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
+        Long leaderId = studyMemberRepository.findLeaderUserIdByStudy(study,
+            StudyMemberRole.LEADER);
         List<StudyMember> studyMembers = studyMemberRepository.findByStudyWithUser(study);
         List<Schedule> schedules = scheduleRepository.findByStudyIdOrderByStartTimeAsc(studyId);
-        List<Attendance> attendances = attendanceRepository.findAllByStudyIdWithScheduleAndUser(studyId);
+        List<Attendance> attendances = attendanceRepository.findAllByStudyIdWithScheduleAndUser(
+            studyId);
         List<StudyMember> orderedMembers = studyMembers.stream()
-                .sorted(Comparator.comparing(sm -> !sm.getUser().getId().equals(leaderId)))
-                .toList();
+            .sorted(Comparator.comparing(sm -> !sm.getUser().getId().equals(leaderId)))
+            .toList();
 
         Map<String, Attendance> attendanceMap = attendances.stream()
-                .collect(Collectors.toMap(
-                        attendance -> attendance.getUser().getId()+ "-" +  attendance.getSchedule().getId(),
-                        attendance -> attendance
-                ));
+            .collect(Collectors.toMap(
+                attendance -> attendance.getUser().getId() + "-" + attendance.getSchedule().getId(),
+                attendance -> attendance
+            ));
 
         // MemberAttendanceDto List 생성
         List<MemberAttendanceDto> memberAttendanceDtoList = orderedMembers.stream()
-                .map(studyMember -> {
-                    User user = studyMember.getUser();
+            .map(studyMember -> {
+                User user = studyMember.getUser();
 
-                    //AttendanceStatusDto List 생성
-                    List<AttendanceStatusDto> attendanceStatusDtoList = schedules.stream()
-                            .map(schedule -> {
-                                Attendance attendance = attendanceMap.get(user.getId() + "-" + schedule.getId());
-                                boolean status = (attendance != null) && (attendance.isStatus());
-                                return new AttendanceStatusDto(status, schedule.getStartTime());
-                            })
-                            .toList();
-                    return new MemberAttendanceDto(user.getNickname(), user.getProfileImageUrl(), attendanceStatusDtoList);
-                })
-                .toList();
+                //AttendanceStatusDto List 생성
+                List<AttendanceStatusDto> attendanceStatusDtoList = schedules.stream()
+                    .map(schedule -> {
+                        Attendance attendance = attendanceMap.get(
+                            user.getId() + "-" + schedule.getId());
+                        boolean status = (attendance != null) && (attendance.isStatus());
+                        return new AttendanceStatusDto(status, schedule.getStartTime());
+                    })
+                    .toList();
+                return new MemberAttendanceDto(user.getNickname(), user.getProfileImageUrl(),
+                    attendanceStatusDtoList);
+            })
+            .toList();
 
         return new AttendanceListResponseDto(memberAttendanceDtoList);
     }
 
 
     @Override
-    public AttendanceStatusResponseDto getIndividualAttendanceStatus(Long studyId, Long scheduleId, User user) {
+    public AttendanceStatusResponseDto getIndividualAttendanceStatus(Long scheduleId, User user) {
         Schedule schedule = checkException(scheduleId, user);
-        return new AttendanceStatusResponseDto(attendanceRepository.existsByScheduleAndUser(schedule, user));
+        return new AttendanceStatusResponseDto(
+            attendanceRepository.existsByScheduleAndUser(schedule, user));
     }
 
 
@@ -84,7 +90,7 @@ public class AttendanceServiceImpl implements AttendanceService {
         Schedule schedule = checkException(scheduleId, user);
 
         // 출석 여부 확인
-        if(attendanceRepository.existsByScheduleAndUser(schedule, user)) {
+        if (attendanceRepository.existsByScheduleAndUser(schedule, user)) {
             throw new BusinessException(ErrorCode.ALREADY_CHECKED_IN);
         }
 
@@ -95,14 +101,14 @@ public class AttendanceServiceImpl implements AttendanceService {
     }
 
     // 공통 예외 검증
-    private Schedule checkException(Long scheduleId, User user){
+    private Schedule checkException(Long scheduleId, User user) {
         // 스케줄 검증
         Schedule schedule = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND));
 
         // 스터디 검증
         Study study = studyRepository.findById(schedule.getStudyId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
 
         // 스터디 멤버 검증
         if (!studyMemberRepository.existsByStudyAndUser(study, user)) {

--- a/src/main/java/com/pado/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/pado/domain/schedule/controller/ScheduleController.java
@@ -68,11 +68,12 @@ public class ScheduleController {
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping("/schedules/me")
     public ResponseEntity<List<ScheduleByDateResponseDto>> getMySchedules(
-            @Parameter(description = "조회할 연도", required = true, example = "2025") @RequestParam int year,
-            @Parameter(description = "조회할 월", required = true, example = "9") @RequestParam int month,
-            @Parameter(hidden = true) @CurrentUser User user
+        @Parameter(description = "조회할 연도", required = true, example = "2025") @RequestParam int year,
+        @Parameter(description = "조회할 월", required = true, example = "9") @RequestParam int month,
+        @Parameter(hidden = true) @CurrentUser User user
     ) {
-        List<ScheduleByDateResponseDto> schedules = scheduleService.findMySchedulesByMonth(user.getId(), year, month);
+        List<ScheduleByDateResponseDto> schedules = scheduleService.findMySchedulesByMonth(
+            user.getId(), year, month);
         return ResponseEntity.ok(schedules);
     }
 
@@ -97,11 +98,12 @@ public class ScheduleController {
         @Parameter(name = "study_id", description = "일정을 수정할 스터디의 ID", required = true, example = "1"),
         @Parameter(name = "schedule_id", description = "수정할 일정의 ID", required = true, example = "1234")
     })
-    @PutMapping("/studies/{study_id}/schedules/{schedule_id}")
-    public ResponseEntity<Void> updateSchedule(@PathVariable("study_id") Long studyId,
-        @PathVariable("schedule_id") Long scheduleId,
-        @Valid @RequestBody ScheduleCreateRequestDto request) {
-        scheduleService.updateSchedule(studyId, scheduleId, request);
+    @PutMapping("schedules/{scheduleid}")
+    public ResponseEntity<Void> updateSchedule(
+        @PathVariable("scheduleid") Long scheduleId,
+        @Valid @RequestBody ScheduleCreateRequestDto request
+    ) {
+        scheduleService.updateSchedule(scheduleId, request);
         return ResponseEntity.ok().build();
     }
 
@@ -113,10 +115,11 @@ public class ScheduleController {
         @Parameter(name = "study_id", description = "일정을 삭제할 스터디의 ID", required = true, example = "1"),
         @Parameter(name = "schedule_id", description = "삭제할 일정의 ID", required = true, example = "1")
     })
-    @DeleteMapping("/studies/{study_id}/schedules/{schedule_id}")
-    public ResponseEntity<Void> deleteSchedule(@PathVariable("study_id") Long studyId,
-        @PathVariable("schedule_id") Long scheduleId) {
-        scheduleService.deleteSchedule(studyId, scheduleId);
+    @DeleteMapping("schedules/{scheduleid}")
+    public ResponseEntity<Void> deleteSchedule(
+        @PathVariable("scheduleid") Long scheduleId
+    ) {
+        scheduleService.deleteSchedule(scheduleId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/pado/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/pado/domain/schedule/controller/ScheduleController.java
@@ -90,12 +90,12 @@ public class ScheduleController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+
     @Api403ForbiddenStudyLeaderOnlyError
     @Api404ScheduleNotFoundError
     @Operation(summary = "일정 수정", description = "지정된 ID를 가진 일정을 수정합니다. (스터디 리더만 가능)", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponse(responseCode = "200", description = "일정 수정 성공", content = @Content)
     @Parameters({
-        @Parameter(name = "study_id", description = "일정을 수정할 스터디의 ID", required = true, example = "1"),
         @Parameter(name = "schedule_id", description = "수정할 일정의 ID", required = true, example = "1234")
     })
     @PutMapping("schedules/{scheduleid}")
@@ -112,7 +112,6 @@ public class ScheduleController {
     @Operation(summary = "일정 삭제", description = "지정된 ID를 가진 일정을 삭제합니다. (스터디 리더만 가능)")
     @ApiResponse(responseCode = "204", description = "일정 삭제 성공", content = @Content)
     @Parameters({
-        @Parameter(name = "study_id", description = "일정을 삭제할 스터디의 ID", required = true, example = "1"),
         @Parameter(name = "schedule_id", description = "삭제할 일정의 ID", required = true, example = "1")
     })
     @DeleteMapping("schedules/{scheduleid}")

--- a/src/main/java/com/pado/domain/schedule/controller/ScheduleTuneController.java
+++ b/src/main/java/com/pado/domain/schedule/controller/ScheduleTuneController.java
@@ -139,7 +139,6 @@ public class ScheduleTuneController {
         )
     ))
     @Parameters({
-        @Parameter(name = "study_id", description = "스터디 ID", required = true, example = "1"),
         @Parameter(name = "tune_id", description = "조율 ID", required = true, example = "1234")
     })
     @GetMapping("schedule-tunes/{tuneid}")
@@ -188,7 +187,6 @@ public class ScheduleTuneController {
         )
     ))
     @Parameters({
-        @Parameter(name = "study_id", description = "스터디 ID", required = true, example = "1"),
         @Parameter(name = "tune_id", description = "조율 ID", required = true, example = "1234")
     })
     @PostMapping("schedule-tunes/{tuneid}/participants")

--- a/src/main/java/com/pado/domain/schedule/controller/ScheduleTuneController.java
+++ b/src/main/java/com/pado/domain/schedule/controller/ScheduleTuneController.java
@@ -142,12 +142,11 @@ public class ScheduleTuneController {
         @Parameter(name = "study_id", description = "스터디 ID", required = true, example = "1"),
         @Parameter(name = "tune_id", description = "조율 ID", required = true, example = "1234")
     })
-    @GetMapping("/studies/{study_id}/schedule-tunes/{tune_id}")
+    @GetMapping("schedule-tunes/{tuneid}")
     public ResponseEntity<ScheduleTuneDetailResponseDto> getScheduleTuneDetail(
-        @PathVariable("study_id") Long studyId,
-        @PathVariable("tune_id") Long tuneId
+        @PathVariable("tuneid") Long tuneId
     ) {
-        return ResponseEntity.ok(scheduleTuneService.findScheduleTuneDetail(studyId, tuneId));
+        return ResponseEntity.ok(scheduleTuneService.findScheduleTuneDetail(tuneId));
     }
 
     @Api403ForbiddenStudyMemberOnlyError
@@ -192,13 +191,12 @@ public class ScheduleTuneController {
         @Parameter(name = "study_id", description = "스터디 ID", required = true, example = "1"),
         @Parameter(name = "tune_id", description = "조율 ID", required = true, example = "1234")
     })
-    @PostMapping("/studies/{study_id}/schedule-tunes/{tune_id}")
+    @PostMapping("schedule-tunes/{tuneid}/participants")
     public ResponseEntity<ScheduleTuneParticipantResponseDto> participateInScheduleTune(
-        @PathVariable("study_id") Long studyId,
-        @PathVariable("tune_id") Long tuneId,
+        @PathVariable("tuneid") Long tuneId,
         @Valid @org.springframework.web.bind.annotation.RequestBody ScheduleTuneParticipantRequestDto request
     ) {
-        return ResponseEntity.ok(scheduleTuneService.participate(studyId, tuneId, request));
+        return ResponseEntity.ok(scheduleTuneService.participate(tuneId, request));
     }
 
     @Api403ForbiddenStudyLeaderOnlyError

--- a/src/main/java/com/pado/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/pado/domain/schedule/service/ScheduleService.java
@@ -16,7 +16,7 @@ public interface ScheduleService {
 
     ScheduleDetailResponseDto findScheduleDetailById(Long scheduleId);
 
-    void updateSchedule(Long studyId, Long scheduleId, ScheduleCreateRequestDto request);
+    void updateSchedule(Long scheduleId, ScheduleCreateRequestDto request);
 
-    void deleteSchedule(Long studyId, Long scheduleId);
+    void deleteSchedule(Long scheduleId);
 }

--- a/src/main/java/com/pado/domain/schedule/service/ScheduleTuneService.java
+++ b/src/main/java/com/pado/domain/schedule/service/ScheduleTuneService.java
@@ -15,9 +15,9 @@ public interface ScheduleTuneService {
 
     List<ScheduleTuneResponseDto> findAllScheduleTunes(Long studyId);
 
-    ScheduleTuneDetailResponseDto findScheduleTuneDetail(Long studyId, Long tuneId);
+    ScheduleTuneDetailResponseDto findScheduleTuneDetail(Long tuneId);
 
-    ScheduleTuneParticipantResponseDto participate(Long studyId, Long tuneId,
+    ScheduleTuneParticipantResponseDto participate(Long tuneId,
         ScheduleTuneParticipantRequestDto request);
 
     ScheduleCompleteResponseDto complete(Long tuneId, ScheduleCreateRequestDto request);

--- a/src/main/java/com/pado/global/config/SecurityConfig.java
+++ b/src/main/java/com/pado/global/config/SecurityConfig.java
@@ -33,10 +33,14 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**", "/swagger-ui/**", "/swagger-resources/**",
                     "/api-docs/**", "/actuator/health").permitAll()
-                    .requestMatchers("/api/upload/**", "/api/download/**").permitAll()
-                    .requestMatchers("/api/studies/*/apply", "/api/studies/*/member/**").authenticated()
-                    .requestMatchers(HttpMethod.GET, "/api/studies/**").permitAll()
-                    .anyRequest().authenticated()
+                .requestMatchers("/api/upload/**", "/api/download/**").permitAll()
+                .requestMatchers("/api/studies/*/apply", "/api/studies/*/member/**").authenticated()
+                .requestMatchers(HttpMethod.GET, "/api/studies/*/schedule-tunes/**").authenticated()
+                .requestMatchers(HttpMethod.GET, "/api/studies/*/attendance/**").authenticated()
+                .requestMatchers("/api/schedules/**").authenticated()
+                .requestMatchers("/api/schedule-tunes/**").authenticated()
+                .requestMatchers(HttpMethod.GET, "/api/studies/**").permitAll()
+                .anyRequest().authenticated()
             )
             .addFilterBefore(
                 new JwtAuthenticationFilter(jwtProvider, customUserDetailsService, objectMapper),

--- a/src/test/java/com/pado/domain/attendance/service/AttendanceServiceImplTest.java
+++ b/src/test/java/com/pado/domain/attendance/service/AttendanceServiceImplTest.java
@@ -1,6 +1,5 @@
 package com.pado.domain.attendance.service;
 
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 import static org.mockito.ArgumentMatchers.any;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,47 +55,48 @@ class AttendanceServiceImplTest {
 
     private User testUser(Long id) {
         User u = User.builder()
-                .email("test@test.com")
-                .passwordHash("hashed")
-                .nickname("tester")
-                .region(Region.SEOUL)
-                .gender(Gender.MALE)
-                .build();
+            .email("test@test.com")
+            .passwordHash("hashed")
+            .nickname("tester")
+            .region(Region.SEOUL)
+            .gender(Gender.MALE)
+            .build();
         ReflectionTestUtils.setField(u, "id", id);
         return u;
     }
 
     private User testUser(Long id, String name) {
         User u = User.builder()
-                .email("test@test.com")
-                .passwordHash("hashed")
-                .nickname(name)
-                .region(Region.SEOUL)
-                .gender(Gender.MALE)
-                .build();
+            .email("test@test.com")
+            .passwordHash("hashed")
+            .nickname(name)
+            .region(Region.SEOUL)
+            .gender(Gender.MALE)
+            .build();
         ReflectionTestUtils.setField(u, "id", id);
         return u;
     }
 
     private Schedule testSchedule(Long id, Long studyId, LocalDateTime startDate) {
-        Schedule s =  Schedule.builder()
-                .studyId(studyId)
-                .title("스터디 일정")
-                .description("설명")
-                .startTime(startDate)
-                .endTime(startDate.plusDays(1))
-                .build();
+        Schedule s = Schedule.builder()
+            .studyId(studyId)
+            .title("스터디 일정")
+            .description("설명")
+            .startTime(startDate)
+            .endTime(startDate.plusDays(1))
+            .build();
         ReflectionTestUtils.setField(s, "id", id);
         return s;
     }
+
     private Schedule testSchedule(Long studyId) {
         return Schedule.builder()
-                .studyId(studyId)
-                .title("스터디 일정")
-                .description("설명")
-                .startTime(LocalDateTime.now())
-                .endTime(LocalDateTime.now().plusHours(2))
-                .build();
+            .studyId(studyId)
+            .title("스터디 일정")
+            .description("설명")
+            .startTime(LocalDateTime.now())
+            .endTime(LocalDateTime.now().plusHours(2))
+            .build();
     }
 
     private Study testStudy(Long id) {
@@ -105,21 +105,21 @@ class AttendanceServiceImplTest {
 
     private Attendance testAttendance(Long id, Schedule schedule, User user, boolean status) {
         Attendance a = Attendance.builder()
-                .schedule(schedule)
-                .user(user)
-                .status(status)
-                .checkInTime(LocalDateTime.now())
-                .build();
+            .schedule(schedule)
+            .user(user)
+            .status(status)
+            .checkInTime(LocalDateTime.now())
+            .build();
         ReflectionTestUtils.setField(a, "id", id);
         return a;
     }
 
     private StudyMember testStudyMember(Study study, User user, StudyMemberRole role) {
         return StudyMember.builder()
-                .study(study)
-                .user(user)
-                .role(role)
-                .build();
+            .study(study)
+            .user(user)
+            .role(role)
+            .build();
     }
 
     @Test
@@ -133,8 +133,8 @@ class AttendanceServiceImplTest {
 
         // when & then
         assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ErrorCode.SCHEDULE_NOT_FOUND.message);
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(ErrorCode.SCHEDULE_NOT_FOUND.message);
     }
 
     @Test
@@ -147,14 +147,13 @@ class AttendanceServiceImplTest {
         User user = testUser(userId);
         Schedule schedule = testSchedule(studyId);
 
-
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
         given(studyRepository.findById(studyId)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ErrorCode.STUDY_NOT_FOUND.message);
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(ErrorCode.STUDY_NOT_FOUND.message);
     }
 
     @Test
@@ -174,8 +173,8 @@ class AttendanceServiceImplTest {
 
         // when & then
         assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY.message);
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY.message);
     }
 
     @Test
@@ -196,8 +195,8 @@ class AttendanceServiceImplTest {
 
         // when & then
         assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ErrorCode.ALREADY_CHECKED_IN.message);
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(ErrorCode.ALREADY_CHECKED_IN.message);
     }
 
     @Test
@@ -226,7 +225,7 @@ class AttendanceServiceImplTest {
 
     @Test
     @DisplayName("출석한 경우 개별 출석 여부 확인")
-    void 개별_출석_확인_출석(){
+    void 개별_출석_확인_출석() {
         // given
         Long userId = 10L;
         Long scheduleId = 1L;
@@ -240,7 +239,8 @@ class AttendanceServiceImplTest {
         given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(true);
         given(attendanceRepository.existsByScheduleAndUser(schedule, user)).willReturn(true);
 
-        AttendanceStatusResponseDto response = attendanceService.getIndividualAttendanceStatus(studyId, scheduleId, user);
+        AttendanceStatusResponseDto response = attendanceService.getIndividualAttendanceStatus(
+            scheduleId, user);
         assertThat(response).isNotNull();
         assertThat(response.status()).isTrue();
         then(attendanceRepository).should(times(0)).save(any(Attendance.class));
@@ -248,7 +248,7 @@ class AttendanceServiceImplTest {
 
     @Test
     @DisplayName("미출석한 경우 개별 출석 여부 확인")
-    void 개별_출석_확인_미출석(){
+    void 개별_출석_확인_미출석() {
         // given
         Long userId = 10L;
         Long scheduleId = 1L;
@@ -262,7 +262,8 @@ class AttendanceServiceImplTest {
         given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(true);
         given(attendanceRepository.existsByScheduleAndUser(schedule, user)).willReturn(false);
 
-        AttendanceStatusResponseDto response = attendanceService.getIndividualAttendanceStatus(studyId, scheduleId, user);
+        AttendanceStatusResponseDto response = attendanceService.getIndividualAttendanceStatus(
+            scheduleId, user);
         assertThat(response).isNotNull();
         assertThat(response.status()).isFalse();
         then(attendanceRepository).should(times(0)).save(any(Attendance.class));
@@ -282,22 +283,22 @@ class AttendanceServiceImplTest {
         StudyMember sm2 = testStudyMember(study, u2, StudyMemberRole.LEADER);
         List<StudyMember> members = List.of(sm1, sm2);
 
-        // 스케줄 3개 (시간순 정렬 가정)
         LocalDateTime base = LocalDateTime.now().withNano(0);
         Schedule sc1 = testSchedule(11L, studyId, base.plusDays(1));
         Schedule sc2 = testSchedule(12L, studyId, base.plusDays(2));
         Schedule sc3 = testSchedule(13L, studyId, base.plusDays(3));
         List<Schedule> schedules = List.of(sc1, sc2, sc3);
 
-        // Attendance: u1은 sc1만 출석(true)
         Attendance a1 = testAttendance(1000L, sc1, u1, true);
         List<Attendance> attendanceList = List.of(a1);
 
         given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
         given(studyMemberRepository.findByStudyWithUser(study)).willReturn(members);
         given(scheduleRepository.findByStudyIdOrderByStartTimeAsc(studyId)).willReturn(schedules);
-        given(attendanceRepository.findAllByStudyIdWithScheduleAndUser(studyId)).willReturn(attendanceList);
-        given(studyMemberRepository.findLeaderUserIdByStudy(study, StudyMemberRole.LEADER)).willReturn(u2.getId());
+        given(attendanceRepository.findAllByStudyIdWithScheduleAndUser(studyId)).willReturn(
+            attendanceList);
+        given(studyMemberRepository.findLeaderUserIdByStudy(study,
+            StudyMemberRole.LEADER)).willReturn(u2.getId());
 
         // when
         AttendanceListResponseDto resp = attendanceService.getFullAttendance(studyId);
@@ -305,33 +306,23 @@ class AttendanceServiceImplTest {
         // then
         assertThat(resp).isNotNull();
 
-        // record 스타일 가정: members()
         List<MemberAttendanceDto> resultMembers = resp.members();
         assertThat(resultMembers).hasSize(2);
 
-        // 멤버별 상태 길이는 스케줄 개수와 동일해야 함
         MemberAttendanceDto m1 = resultMembers.get(0);
         MemberAttendanceDto m2 = resultMembers.get(1);
 
         assertThat(m1.attendance()).hasSize(3);
         assertThat(m2.attendance()).hasSize(3);
-
-        // u2: [false, false, false], 리더가 먼저 출력되는지 확인
         assertThat(m1.name()).isEqualTo("u2");
         assertThat(m1.attendance().stream().allMatch(s -> !s.status())).isTrue();
-
-
-        // u1: [true, false, false]
         assertThat(m2.name()).isEqualTo("u1");
         assertThat(m2.attendance().get(0).status()).isTrue();
         assertThat(m2.attendance().get(1).status()).isFalse();
         assertThat(m2.attendance().get(2).status()).isFalse();
-
-        // 스케줄 시간 정렬 보장 체크
         assertThat(m1.attendance().get(0).schedule_date()).isEqualTo(sc1.getStartTime());
         assertThat(m1.attendance().get(1).schedule_date()).isEqualTo(sc2.getStartTime());
         assertThat(m1.attendance().get(2).schedule_date()).isEqualTo(sc3.getStartTime());
-
 
         then(studyRepository).should(times(1)).findById(studyId);
         then(studyMemberRepository).should(times(1)).findByStudyWithUser(study);

--- a/src/test/java/com/pado/domain/schedule/controller/ScheduleTuneControllerTest.java
+++ b/src/test/java/com/pado/domain/schedule/controller/ScheduleTuneControllerTest.java
@@ -126,9 +126,9 @@ class ScheduleTuneControllerTest {
                 LocalDateTime.now().plusDays(1).withHour(12),
                 List.of(new ScheduleTuneParticipantDto(1L, "Alice", 1L))
             );
-            given(scheduleTuneService.findScheduleTuneDetail(1L, 100L)).willReturn(dto);
+            given(scheduleTuneService.findScheduleTuneDetail(100L)).willReturn(dto);
 
-            mockMvc.perform(get("/api/studies/{study_id}/schedule-tunes/{tune_id}", 1L, 100L))
+            mockMvc.perform(get("/api/schedule-tunes/{tune_id}", 100L))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("정기회의"))
@@ -139,10 +139,10 @@ class ScheduleTuneControllerTest {
         @WithMockUser
         @DisplayName("상세 실패 - 404 Not Found")
         void detail_not_found() throws Exception {
-            given(scheduleTuneService.findScheduleTuneDetail(1L, 999L))
+            given(scheduleTuneService.findScheduleTuneDetail(999L))
                 .willThrow(new BusinessException(ErrorCode.PENDING_SCHEDULE_NOT_FOUND));
 
-            mockMvc.perform(get("/api/studies/{study_id}/schedule-tunes/{tune_id}", 1L, 999L))
+            mockMvc.perform(get("/api/schedule-tunes/{tune_id}", 999L))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("PENDING_SCHEDULE_NOT_FOUND"));
@@ -159,10 +159,10 @@ class ScheduleTuneControllerTest {
         void participate_success() throws Exception {
             ScheduleTuneParticipantRequestDto req = new ScheduleTuneParticipantRequestDto(
                 List.of(1L, 0L, 1L));
-            given(scheduleTuneService.participate(anyLong(), anyLong(), any()))
+            given(scheduleTuneService.participate(anyLong(), any()))
                 .willReturn(new ScheduleTuneParticipantResponseDto("updated"));
 
-            mockMvc.perform(post("/api/studies/{study_id}/schedule-tunes/{tune_id}", 1L, 100L)
+            mockMvc.perform(post("/api/schedule-tunes/{tune_id}/participants", 100L)
                     .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(req)))
@@ -177,10 +177,10 @@ class ScheduleTuneControllerTest {
         void participate_forbidden() throws Exception {
             ScheduleTuneParticipantRequestDto req = new ScheduleTuneParticipantRequestDto(
                 List.of(1L));
-            given(scheduleTuneService.participate(anyLong(), anyLong(), any()))
+            given(scheduleTuneService.participate(anyLong(), any()))
                 .willThrow(new BusinessException(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY));
 
-            mockMvc.perform(post("/api/studies/{study_id}/schedule-tunes/{tune_id}", 1L, 100L)
+            mockMvc.perform(post("/api/schedule-tunes/{tune_id}/participants", 100L)
                     .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(req)))

--- a/src/test/java/com/pado/domain/schedule/service/ScheduleTuneServiceTest.java
+++ b/src/test/java/com/pado/domain/schedule/service/ScheduleTuneServiceTest.java
@@ -179,7 +179,7 @@ class ScheduleTuneServiceTest {
                 .availableEndTime(LocalTime.of(11, 0))
                 .slotMinutes(30).status(ScheduleTuneStatus.PENDING).build();
             ReflectionTestUtils.setField(tune, "id", 777L);
-            given(tuneRepo.findByIdAndStudyId(777L, 10L)).willReturn(Optional.of(tune));
+            given(tuneRepo.findById(777L)).willReturn(Optional.of(tune));
 
             StudyMember sm = StudyMember.builder().study(study).user(member).build();
             ReflectionTestUtils.setField(sm, "id", 100L);
@@ -208,7 +208,7 @@ class ScheduleTuneServiceTest {
             ScheduleTuneParticipantRequestDto req = new ScheduleTuneParticipantRequestDto(
                 List.of(1L, 0L));
 
-            ScheduleTuneParticipantResponseDto resp = service.participate(10L, 777L, req);
+            ScheduleTuneParticipantResponseDto resp = service.participate(777L, req);
             assertThat(resp.message()).isEqualTo("updated");
             assertThat(BitMaskUtils.popcount(s1.getOccupancyBits())).isEqualTo(1);
             assertThat(BitMaskUtils.popcount(s2.getOccupancyBits())).isEqualTo(0);
@@ -259,7 +259,7 @@ class ScheduleTuneServiceTest {
         }
 
         @Test
-        @DisplayName("슬롯과 불일치하면 INVALID_INPUT")
+        @DisplayName("슬롯과 불일치하면 INVALIDINPUT")
         void complete_slot_mismatch() {
             setAuth(leader);
 
@@ -275,8 +275,7 @@ class ScheduleTuneServiceTest {
             given(tuneRepo.findById(777L)).willReturn(Optional.of(tune));
             given(studyRepo.findById(10L)).willReturn(Optional.of(study));
             given(studyMemberService.isStudyLeader(leader, study)).willReturn(true);
-            given(slotRepo.findByScheduleTuneIdOrderBySlotIndexAsc(777L)).willReturn(
-                List.of());
+            given(slotRepo.findByScheduleTuneIdOrderBySlotIndexAsc(777L)).willReturn(List.of());
 
             LocalDateTime st = LocalDateTime.now().plusDays(1).withHour(10);
             LocalDateTime et = st.plusMinutes(30);


### PR DESCRIPTION
## ✨ 요약

> 일정, 일정 조율, 출석 api의 경로를 아래와 같이 수정했습니다.

[일정]
수정: PUT /api/schedules/{schedule_id}
삭제: DELETE /api/schedules/{schedule_id}

[일정 조율]
상세 조회: GET /api/schedule-tunes/{tune_id}
참여: POST /api/schedule-tunes/{tune_id}/participants

[출석]
개별 참여 조회: GET /api/schedules/{schedule_id}/attendance

## 🔗 작업 내용
- api 경로 수정 및 테스트 코드 변경


## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #80 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)