### PR TITLE
feat(cors): Vercel 도메인 및 localhost:3000 허용 + Spring Security CORS 활성화

### DIFF
--- a/src/main/java/com/pado/global/config/CorsConfig.java
+++ b/src/main/java/com/pado/global/config/CorsConfig.java
@@ -10,14 +10,16 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins(
-                        "https://gogumalatte.site",
-                        "http://localhost:3000",
-                        "http://localhost:8080"
-                )
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(true)
-                .maxAge(3600);
+            .allowedOrigins(
+                "https://gogumalatte.site",
+                "http://localhost:3000",
+                "http://localhost:8080",
+                "https://pado-study.vercel.app",
+                "https://pado-dev.vercel.app"
+            )
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+            .maxAge(3600);
     }
 }

--- a/src/main/java/com/pado/global/config/SecurityConfig.java
+++ b/src/main/java/com/pado/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -28,7 +29,8 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable)
+        http.cors(Customizer.withDefaults())
+            .csrf(AbstractHttpConfigurer::disable)
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**", "/swagger-ui/**", "/swagger-resources/**",


### PR DESCRIPTION
## ✨ 요약

> 프론트엔드 개발 환경과 배포 환경에서 교차 출처 요청을 허용하기 위해 프론트엔드 도메인을 CORS 허용 목록에 추가하고, Security 필터 체인에서 CORS 처리를 활성화했습니다.

## 🔗 작업 내용

- 전역 CORS 설정(CorsConfig)에서 allowedOrigins에 https://pado-study.vercel.app/, https://pado-dev.vercel.app/ 을 추가했습니다.
- Spring Security는 CORS를 별도 필터로 처리하므로 SecurityFilterChain에서 cors(Customizer.withDefaults())를 추가해 WebMvcConfigurer 설정이 응답 헤더에 반영되도록 했습니다.
- 

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

## 🔗 참고 사항
프론트엔드의 로컬 환경과 운영 환경에서 api 통신이 잘 이루어지는지 확인이 필요합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #83 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)