### PR TITLE
Fix: swagger 로그인 500 에러

### DIFF
--- a/src/main/java/com/pado/global/config/SecurityConfig.java
+++ b/src/main/java/com/pado/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**", "/swagger-ui/**", "/swagger-resources/**",
-                    "/api-docs/**", "/actuator/health").permitAll()
+                    "/api-docs/**", "/v3/api-docs/**", "/actuator/health").permitAll()
                 .requestMatchers("/api/upload/**", "/api/download/**").permitAll()
                 .requestMatchers("/api/studies/*/apply", "/api/studies/*/member/**").authenticated()
                 .requestMatchers(HttpMethod.GET, "/api/studies/*/schedule-tunes/**").authenticated()


### PR DESCRIPTION
## ✨ 요약

>springdoc 2.x 기본 스펙 경로는 /v3/api-docs/** 이다. 현재는 /api-docs/**만 허용되어 환경에 따라 Swagger에서 스펙/호출이 차단될 수 있다. 명시적으로 허용해 Swagger 경유 로그인 요청이 필터에서 막히지 않도록 했다.

## 🔗 작업 내용

- 
- 
- 

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #93 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)