### PR TITLE
refactor: DashboardService 시간 의존성을 Clock 주입으로 변경

### DIFF
--- a/src/main/java/com/pado/domain/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/pado/domain/dashboard/service/DashboardServiceImpl.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
@@ -29,14 +30,13 @@ public class DashboardServiceImpl implements DashboardService {
     private final ScheduleRepository scheduleRepository;
     private final StudyMemberRepository studyMemberRepository;
     private final AttendanceRepository attendanceRepository;
+    private final Clock clock;
 
     public StudyDashboardResponseDto getStudyDashboard(Long studyId) {
-        return getStudyDashboard(studyId, LocalDateTime.now());
-    }
-
-    private StudyDashboardResponseDto getStudyDashboard(Long studyId, LocalDateTime now) {
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now(clock);
 
         LatestNoticeDto latestNotice = findLatestNotice(studyId);
         UpcomingScheduleDto upcomingSchedule = findUpcomingSchedule(studyId, now);

--- a/src/main/java/com/pado/global/config/AppConfig.java
+++ b/src/main/java/com/pado/global/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.pado.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import java.time.Clock;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}


### PR DESCRIPTION
## ✨ 요약

>getStudyDashboard 메서드에서 public/private 분리로 인한 가독성 문제를 개선하기 위한 리팩토링입니다.

## 🔗 작업 내용
- public/private로 나뉜 getStudyDashboard 메서드 합침
- `java.time.Clock`을 주입받아 현재 시간을 참조하도록 리팩토링


## 🔗 관련 이슈

- Close #97 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)