### PR TITLE
feat: 스터디 회고 api

### DIFF
--- a/src/main/java/com/pado/domain/reflection/controller/ReflectionController.java
+++ b/src/main/java/com/pado/domain/reflection/controller/ReflectionController.java
@@ -4,11 +4,22 @@ import com.pado.domain.reflection.dto.*;
 import com.pado.domain.reflection.service.ReflectionService;
 import com.pado.global.auth.annotation.CurrentUser;
 import com.pado.domain.user.entity.User;
+import com.pado.global.swagger.annotation.reflection.Api403ForbiddenReflectionOwnerError;
+import com.pado.global.swagger.annotation.reflection.Api404ReflectionNotFoundError;
+import com.pado.global.swagger.annotation.study.Api403ForbiddenStudyMemberOnlyError;
+import com.pado.global.swagger.annotation.study.Api404StudyNotFoundError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
+@Tag(name = "13. Reflection", description = "스터디 회고 관련 API")
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -16,42 +27,62 @@ public class ReflectionController {
 
     private final ReflectionService reflectionService;
 
+    @Operation(summary = "회고 작성", description = "특정 스터디에 대한 회고를 작성합니다. (스터디 멤버만 가능)")
+    @ApiResponse(responseCode = "200", description = "회고 작성 성공")
+    @Api404StudyNotFoundError
+    @Api403ForbiddenStudyMemberOnlyError
     @PostMapping("/studies/{study_id}/reflections")
     public ResponseEntity<ReflectionResponseDto> createReflection(
-        @PathVariable("study_id") Long studyId,
-        @CurrentUser User user,
-        @RequestBody ReflectionCreateRequestDto request
+        @Parameter(description = "회고를 작성할 스터디 ID") @PathVariable("study_id") Long studyId,
+        @Parameter(hidden = true) @CurrentUser User user,
+        @Valid @RequestBody ReflectionCreateRequestDto request
     ) {
         return ResponseEntity.ok(reflectionService.createReflection(studyId, user, request));
     }
 
+    @Operation(summary = "스터디 전체 회고 조회", description = "특정 스터디에 작성된 모든 회고를 조회합니다. (스터디 멤버만 가능)")
+    @ApiResponse(responseCode = "200", description = "회고 목록 조회 성공")
+    @Api404StudyNotFoundError
+    @Api403ForbiddenStudyMemberOnlyError
     @GetMapping("/studies/{study_id}/reflections")
     public ResponseEntity<List<ReflectionResponseDto>> getReflections(
-        @PathVariable("study_id") Long studyId,
-        @CurrentUser User user) {
+        @Parameter(description = "회고를 조회할 스터디 ID") @PathVariable("study_id") Long studyId,
+        @Parameter(hidden = true) @CurrentUser User user) {
         return ResponseEntity.ok(reflectionService.getReflections(studyId, user));
     }
 
+    @Operation(summary = "회고 상세 조회", description = "특정 회고의 상세 내용을 조회합니다. (스터디 멤버만 가능)")
+    @ApiResponse(responseCode = "200", description = "회고 상세 조회 성공")
+    @Api404ReflectionNotFoundError
+    @Api403ForbiddenStudyMemberOnlyError
     @GetMapping("/reflections/{reflection_id}")
     public ResponseEntity<ReflectionResponseDto> getReflection(
-        @PathVariable("reflection_id") Long reflectionId,
-        @CurrentUser User user) {
+        @Parameter(description = "조회할 회고 ID") @PathVariable("reflection_id") Long reflectionId,
+        @Parameter(hidden = true) @CurrentUser User user) {
         return ResponseEntity.ok(reflectionService.getReflection(reflectionId, user));
     }
 
+    @Operation(summary = "회고 수정", description = "자신이 작성한 회고를 수정합니다. (작성자 본인만 가능)")
+    @ApiResponse(responseCode = "200", description = "회고 수정 성공")
+    @Api404ReflectionNotFoundError
+    @Api403ForbiddenReflectionOwnerError
     @PatchMapping("/reflections/{reflection_id}")
     public ResponseEntity<ReflectionResponseDto> updateReflection(
-        @PathVariable("reflection_id") Long reflectionId,
-        @CurrentUser User user,
-        @RequestBody ReflectionCreateRequestDto request
+        @Parameter(description = "수정할 회고 ID") @PathVariable("reflection_id") Long reflectionId,
+        @Parameter(hidden = true) @CurrentUser User user,
+        @Valid @RequestBody ReflectionCreateRequestDto request
     ) {
         return ResponseEntity.ok(reflectionService.updateReflection(reflectionId, user, request));
     }
 
+    @Operation(summary = "회고 삭제", description = "자신이 작성한 회고를 삭제합니다. (작성자 본인만 가능)")
+    @ApiResponse(responseCode = "204", description = "회고 삭제 성공")
+    @Api404ReflectionNotFoundError
+    @Api403ForbiddenReflectionOwnerError
     @DeleteMapping("/reflections/{reflection_id}")
     public ResponseEntity<Void> deleteReflection(
-        @PathVariable("reflection_id") Long reflectionId,
-        @CurrentUser User user) {
+        @Parameter(description = "삭제할 회고 ID") @PathVariable("reflection_id") Long reflectionId,
+        @Parameter(hidden = true) @CurrentUser User user) {
         reflectionService.deleteReflection(reflectionId, user);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/pado/domain/reflection/controller/ReflectionController.java
+++ b/src/main/java/com/pado/domain/reflection/controller/ReflectionController.java
@@ -1,0 +1,60 @@
+package com.pado.domain.reflection.controller;
+
+import com.pado.domain.reflection.dto.*;
+import com.pado.domain.reflection.service.ReflectionService;
+import com.pado.domain.study.entity.StudyMember;
+import com.pado.domain.study.repository.StudyMemberRepository;
+import com.pado.global.auth.annotation.CurrentUser;
+import com.pado.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ReflectionController {
+
+    private final ReflectionService reflectionService;
+    private final StudyMemberRepository studyMemberRepository;
+
+    @PostMapping("/studies/{study_id}/reflections")
+    public ResponseEntity<ReflectionResponseDto> createReflection(
+        @PathVariable("study_id") Long studyId,
+        @CurrentUser User user,
+        @RequestBody ReflectionCreateRequestDto request
+    ) {
+        StudyMember studyMember = studyMemberRepository.findByStudyIdAndUserId(studyId,
+                user.getId())
+            .orElseThrow(() -> new IllegalArgumentException("스터디 멤버가 아닙니다."));
+        return ResponseEntity.ok(
+            reflectionService.createReflection(studyId, studyMember.getId(), request));
+    }
+
+    @GetMapping("/studies/{study_id}/reflections")
+    public ResponseEntity<List<ReflectionResponseDto>> getReflections(
+        @PathVariable("study_id") Long studyId) {
+        return ResponseEntity.ok(reflectionService.getReflections(studyId));
+    }
+
+    @GetMapping("/reflections/{reflection_id}")
+    public ResponseEntity<ReflectionResponseDto> getReflection(
+        @PathVariable("reflection_id") Long reflectionId) {
+        return ResponseEntity.ok(reflectionService.getReflection(reflectionId));
+    }
+
+    @PatchMapping("/reflections/{reflection_id}")
+    public ResponseEntity<ReflectionResponseDto> updateReflection(
+        @PathVariable("reflection_id") Long reflectionId,
+        @RequestBody ReflectionCreateRequestDto request
+    ) {
+        return ResponseEntity.ok(reflectionService.updateReflection(reflectionId, request));
+    }
+
+    @DeleteMapping("/reflections/{reflection_id}")
+    public ResponseEntity<Void> deleteReflection(@PathVariable("reflection_id") Long reflectionId) {
+        reflectionService.deleteReflection(reflectionId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/pado/domain/reflection/controller/ReflectionController.java
+++ b/src/main/java/com/pado/domain/reflection/controller/ReflectionController.java
@@ -2,8 +2,6 @@ package com.pado.domain.reflection.controller;
 
 import com.pado.domain.reflection.dto.*;
 import com.pado.domain.reflection.service.ReflectionService;
-import com.pado.domain.study.entity.StudyMember;
-import com.pado.domain.study.repository.StudyMemberRepository;
 import com.pado.global.auth.annotation.CurrentUser;
 import com.pado.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +15,6 @@ import java.util.List;
 public class ReflectionController {
 
     private final ReflectionService reflectionService;
-    private final StudyMemberRepository studyMemberRepository;
 
     @PostMapping("/studies/{study_id}/reflections")
     public ResponseEntity<ReflectionResponseDto> createReflection(
@@ -25,36 +22,37 @@ public class ReflectionController {
         @CurrentUser User user,
         @RequestBody ReflectionCreateRequestDto request
     ) {
-        StudyMember studyMember = studyMemberRepository.findByStudyIdAndUserId(studyId,
-                user.getId())
-            .orElseThrow(() -> new IllegalArgumentException("스터디 멤버가 아닙니다."));
-        return ResponseEntity.ok(
-            reflectionService.createReflection(studyId, studyMember.getId(), request));
+        return ResponseEntity.ok(reflectionService.createReflection(studyId, user, request));
     }
 
     @GetMapping("/studies/{study_id}/reflections")
     public ResponseEntity<List<ReflectionResponseDto>> getReflections(
-        @PathVariable("study_id") Long studyId) {
-        return ResponseEntity.ok(reflectionService.getReflections(studyId));
+        @PathVariable("study_id") Long studyId,
+        @CurrentUser User user) {
+        return ResponseEntity.ok(reflectionService.getReflections(studyId, user));
     }
 
     @GetMapping("/reflections/{reflection_id}")
     public ResponseEntity<ReflectionResponseDto> getReflection(
-        @PathVariable("reflection_id") Long reflectionId) {
-        return ResponseEntity.ok(reflectionService.getReflection(reflectionId));
+        @PathVariable("reflection_id") Long reflectionId,
+        @CurrentUser User user) {
+        return ResponseEntity.ok(reflectionService.getReflection(reflectionId, user));
     }
 
     @PatchMapping("/reflections/{reflection_id}")
     public ResponseEntity<ReflectionResponseDto> updateReflection(
         @PathVariable("reflection_id") Long reflectionId,
+        @CurrentUser User user,
         @RequestBody ReflectionCreateRequestDto request
     ) {
-        return ResponseEntity.ok(reflectionService.updateReflection(reflectionId, request));
+        return ResponseEntity.ok(reflectionService.updateReflection(reflectionId, user, request));
     }
 
     @DeleteMapping("/reflections/{reflection_id}")
-    public ResponseEntity<Void> deleteReflection(@PathVariable("reflection_id") Long reflectionId) {
-        reflectionService.deleteReflection(reflectionId);
+    public ResponseEntity<Void> deleteReflection(
+        @PathVariable("reflection_id") Long reflectionId,
+        @CurrentUser User user) {
+        reflectionService.deleteReflection(reflectionId, user);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/pado/domain/reflection/dto/ReflectionCreateRequestDto.java
+++ b/src/main/java/com/pado/domain/reflection/dto/ReflectionCreateRequestDto.java
@@ -1,0 +1,14 @@
+package com.pado.domain.reflection.dto;
+
+import jakarta.validation.constraints.*;
+
+public record ReflectionCreateRequestDto(
+    Long scheduleId,
+    @NotNull Integer satisfactionScore,
+    @NotNull Integer understandingScore,
+    @NotNull Integer participationScore,
+    @NotBlank String learnedContent,
+    @NotBlank String improvement
+) {
+
+}

--- a/src/main/java/com/pado/domain/reflection/dto/ReflectionCreateRequestDto.java
+++ b/src/main/java/com/pado/domain/reflection/dto/ReflectionCreateRequestDto.java
@@ -1,14 +1,32 @@
 package com.pado.domain.reflection.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
+@Schema(description = "회고 생성 및 수정 요청 DTO")
 public record ReflectionCreateRequestDto(
+    @Schema(description = "연관된 스터디 일정 ID (선택)", example = "10")
     Long scheduleId,
-    @NotNull Integer satisfactionScore,
-    @NotNull Integer understandingScore,
-    @NotNull Integer participationScore,
-    @NotBlank String learnedContent,
-    @NotBlank String improvement
+
+    @Schema(description = "스터디 만족도 점수 (1~5)", example = "5")
+    @NotNull @Min(1) @Max(5)
+    Integer satisfactionScore,
+
+    @Schema(description = "스터디 이해도 점수 (1~5)", example = "4")
+    @NotNull @Min(1) @Max(5)
+    Integer understandingScore,
+
+    @Schema(description = "스터디 참여도 점수 (1~5)", example = "5")
+    @NotNull @Min(1) @Max(5)
+    Integer participationScore,
+
+    @Schema(description = "배운 내용", example = "JPA 영속성 컨텍스트에 대해 깊이 이해했습니다.")
+    @NotBlank
+    String learnedContent,
+
+    @Schema(description = "개선할 점", example = "다음 스터디 전까지 관련 예제 코드를 직접 작성해봐야겠습니다.")
+    @NotBlank
+    String improvement
 ) {
 
 }

--- a/src/main/java/com/pado/domain/reflection/dto/ReflectionResponseDto.java
+++ b/src/main/java/com/pado/domain/reflection/dto/ReflectionResponseDto.java
@@ -1,0 +1,19 @@
+package com.pado.domain.reflection.dto;
+
+import java.time.LocalDateTime;
+
+public record ReflectionResponseDto(
+    Long id,
+    Long studyId,
+    Long studyMemberId,
+    Long scheduleId,
+    Integer satisfactionScore,
+    Integer understandingScore,
+    Integer participationScore,
+    String learnedContent,
+    String improvement,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+
+}

--- a/src/main/java/com/pado/domain/reflection/dto/ReflectionResponseDto.java
+++ b/src/main/java/com/pado/domain/reflection/dto/ReflectionResponseDto.java
@@ -1,18 +1,31 @@
 package com.pado.domain.reflection.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
+@Schema(description = "회고 정보 응답 DTO")
 public record ReflectionResponseDto(
+    @Schema(description = "회고 ID", example = "1")
     Long id,
+    @Schema(description = "스터디 ID", example = "1")
     Long studyId,
+    @Schema(description = "스터디 멤버 ID", example = "1")
     Long studyMemberId,
+    @Schema(description = "연관된 스터디 일정 ID", example = "10")
     Long scheduleId,
+    @Schema(description = "만족도 점수", example = "5")
     Integer satisfactionScore,
+    @Schema(description = "이해도 점수", example = "4")
     Integer understandingScore,
+    @Schema(description = "참여도 점수", example = "5")
     Integer participationScore,
+    @Schema(description = "배운 내용", example = "JPA 영속성 컨텍스트에 대해 깊이 이해했습니다.")
     String learnedContent,
+    @Schema(description = "개선할 점", example = "다음 스터디 전까지 관련 예제 코드를 직접 작성해봐야겠습니다.")
     String improvement,
+    @Schema(description = "생성 시각", example = "2025-09-26T14:00:00")
     LocalDateTime createdAt,
+    @Schema(description = "수정 시각", example = "2025-09-26T14:10:00")
     LocalDateTime updatedAt
 ) {
 

--- a/src/main/java/com/pado/domain/reflection/entity/Reflection.java
+++ b/src/main/java/com/pado/domain/reflection/entity/Reflection.java
@@ -45,4 +45,14 @@ public class Reflection extends AuditingEntity {
 
     @Column(nullable = false, length = 1000)
     private String improvement;
+
+    public void update(Schedule schedule, Integer satisfactionScore, Integer understandingScore,
+        Integer participationScore, String learnedContent, String improvement) {
+        this.schedule = schedule;
+        this.satisfactionScore = satisfactionScore;
+        this.understandingScore = understandingScore;
+        this.participationScore = participationScore;
+        this.learnedContent = learnedContent;
+        this.improvement = improvement;
+    }
 }

--- a/src/main/java/com/pado/domain/reflection/entity/Reflection.java
+++ b/src/main/java/com/pado/domain/reflection/entity/Reflection.java
@@ -1,0 +1,48 @@
+package com.pado.domain.reflection.entity;
+
+import com.pado.domain.study.entity.Study;
+import com.pado.domain.study.entity.StudyMember;
+import com.pado.domain.schedule.entity.Schedule;
+import com.pado.domain.basetime.AuditingEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Table(name = "reflection")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Reflection extends AuditingEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "study_id", nullable = false)
+    private Study study;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "study_member_id", nullable = false)
+    private StudyMember studyMember;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id")
+    private Schedule schedule;
+
+    @Column(nullable = false)
+    private Integer satisfactionScore;
+
+    @Column(nullable = false)
+    private Integer understandingScore;
+
+    @Column(nullable = false)
+    private Integer participationScore;
+
+    @Column(nullable = false, length = 1000)
+    private String learnedContent;
+
+    @Column(nullable = false, length = 1000)
+    private String improvement;
+}

--- a/src/main/java/com/pado/domain/reflection/repository/ReflectionRepository.java
+++ b/src/main/java/com/pado/domain/reflection/repository/ReflectionRepository.java
@@ -1,0 +1,10 @@
+package com.pado.domain.reflection.repository;
+
+import com.pado.domain.reflection.entity.Reflection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface ReflectionRepository extends JpaRepository<Reflection, Long> {
+
+    List<Reflection> findByStudyId(Long studyId);
+}

--- a/src/main/java/com/pado/domain/reflection/service/ReflectionService.java
+++ b/src/main/java/com/pado/domain/reflection/service/ReflectionService.java
@@ -1,18 +1,21 @@
 package com.pado.domain.reflection.service;
 
 import com.pado.domain.reflection.dto.*;
+import com.pado.domain.user.entity.User;
+
 import java.util.List;
 
 public interface ReflectionService {
 
-    ReflectionResponseDto createReflection(Long studyId, Long studyMemberId,
+    ReflectionResponseDto createReflection(Long studyId, User user,
         ReflectionCreateRequestDto request);
 
-    List<ReflectionResponseDto> getReflections(Long studyId);
+    List<ReflectionResponseDto> getReflections(Long studyId, User user);
 
-    ReflectionResponseDto getReflection(Long reflectionId);
+    ReflectionResponseDto getReflection(Long reflectionId, User user);
 
-    ReflectionResponseDto updateReflection(Long reflectionId, ReflectionCreateRequestDto request);
+    ReflectionResponseDto updateReflection(Long reflectionId, User user,
+        ReflectionCreateRequestDto request);
 
-    void deleteReflection(Long reflectionId);
+    void deleteReflection(Long reflectionId, User user);
 }

--- a/src/main/java/com/pado/domain/reflection/service/ReflectionService.java
+++ b/src/main/java/com/pado/domain/reflection/service/ReflectionService.java
@@ -1,0 +1,18 @@
+package com.pado.domain.reflection.service;
+
+import com.pado.domain.reflection.dto.*;
+import java.util.List;
+
+public interface ReflectionService {
+
+    ReflectionResponseDto createReflection(Long studyId, Long studyMemberId,
+        ReflectionCreateRequestDto request);
+
+    List<ReflectionResponseDto> getReflections(Long studyId);
+
+    ReflectionResponseDto getReflection(Long reflectionId);
+
+    ReflectionResponseDto updateReflection(Long reflectionId, ReflectionCreateRequestDto request);
+
+    void deleteReflection(Long reflectionId);
+}

--- a/src/main/java/com/pado/domain/reflection/service/ReflectionServiceImpl.java
+++ b/src/main/java/com/pado/domain/reflection/service/ReflectionServiceImpl.java
@@ -1,0 +1,104 @@
+package com.pado.domain.reflection.service;
+
+import com.pado.domain.reflection.dto.*;
+import com.pado.domain.reflection.entity.Reflection;
+import com.pado.domain.reflection.repository.ReflectionRepository;
+import com.pado.domain.study.entity.Study;
+import com.pado.domain.study.entity.StudyMember;
+import com.pado.domain.schedule.entity.Schedule;
+import com.pado.domain.study.repository.StudyRepository;
+import com.pado.domain.study.repository.StudyMemberRepository;
+import com.pado.domain.schedule.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReflectionServiceImpl implements ReflectionService {
+
+    private final ReflectionRepository reflectionRepository;
+    private final StudyRepository studyRepository;
+    private final StudyMemberRepository studyMemberRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    @Override
+    @Transactional
+    public ReflectionResponseDto createReflection(Long studyId, Long studyMemberId,
+        ReflectionCreateRequestDto request) {
+        Study study = studyRepository.findById(studyId).orElseThrow();
+        StudyMember member = studyMemberRepository.findById(studyMemberId).orElseThrow();
+        Schedule schedule =
+            request.scheduleId() != null ? scheduleRepository.findById(request.scheduleId())
+                .orElse(null) : null;
+        Reflection reflection = Reflection.builder()
+            .study(study)
+            .studyMember(member)
+            .schedule(schedule)
+            .satisfactionScore(request.satisfactionScore())
+            .understandingScore(request.understandingScore())
+            .participationScore(request.participationScore())
+            .learnedContent(request.learnedContent())
+            .improvement(request.improvement())
+            .build();
+        reflectionRepository.save(reflection);
+        return toDto(reflection);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReflectionResponseDto> getReflections(Long studyId) {
+        return reflectionRepository.findByStudyId(studyId).stream().map(this::toDto)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReflectionResponseDto getReflection(Long reflectionId) {
+        Reflection r = reflectionRepository.findById(reflectionId).orElseThrow();
+        return toDto(r);
+    }
+
+    @Override
+    @Transactional
+    public ReflectionResponseDto updateReflection(Long reflectionId,
+        ReflectionCreateRequestDto request) {
+        Reflection r = reflectionRepository.findById(reflectionId).orElseThrow();
+        Schedule schedule =
+            request.scheduleId() != null ? scheduleRepository.findById(request.scheduleId())
+                .orElse(null) : null;
+        r.update(
+            schedule,
+            request.satisfactionScore(),
+            request.understandingScore(),
+            request.participationScore(),
+            request.learnedContent(),
+            request.improvement()
+        );
+        return toDto(r);
+    }
+    
+    @Override
+    @Transactional
+    public void deleteReflection(Long reflectionId) {
+        reflectionRepository.deleteById(reflectionId);
+    }
+
+    private ReflectionResponseDto toDto(Reflection r) {
+        return new ReflectionResponseDto(
+            r.getId(),
+            r.getStudy().getId(),
+            r.getStudyMember().getId(),
+            r.getSchedule() != null ? r.getSchedule().getId() : null,
+            r.getSatisfactionScore(),
+            r.getUnderstandingScore(),
+            r.getParticipationScore(),
+            r.getLearnedContent(),
+            r.getImprovement(),
+            r.getCreatedAt(),
+            r.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/pado/global/exception/common/ErrorCode.java
+++ b/src/main/java/com/pado/global/exception/common/ErrorCode.java
@@ -11,20 +11,28 @@ public enum ErrorCode {
     // Authentication and Authorization
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTHENTICATION_FAILED", "인증에 실패했습니다."),
     UNAUTHENTICATED_USER(HttpStatus.UNAUTHORIZED, "UNAUTHENTICATED_USER", "인증되지 않은 사용자입니다."),
-    VERIFICATION_CODE_MISMATCH(HttpStatus.UNAUTHORIZED, "VERIFICATION_CODE_MISMATCH", "인증 코드가 일치하지 않습니다."),
-    FORBIDDEN_STUDY_LEADER_ONLY(HttpStatus.FORBIDDEN, "FORBIDDEN_STUDY_LEADER_ONLY", "스터디 리더만 접근할 수 있습니다."),
-    FORBIDDEN_STUDY_MEMBER_ONLY(HttpStatus.FORBIDDEN, "FORBIDDEN_STUDY_MEMBER_ONLY", "스터디 멤버만 접근할 수 있습니다."),
-    FORBIDDEN_OWNER_OR_LEADER_ONLY(HttpStatus.FORBIDDEN, "FORBIDDEN_OWNER_OR_LEADER_ONLY", "소유자 또는 스터디 리더만 접근할 수 있습니다."),
+    VERIFICATION_CODE_MISMATCH(HttpStatus.UNAUTHORIZED, "VERIFICATION_CODE_MISMATCH",
+        "인증 코드가 일치하지 않습니다."),
+    FORBIDDEN_STUDY_LEADER_ONLY(HttpStatus.FORBIDDEN, "FORBIDDEN_STUDY_LEADER_ONLY",
+        "스터디 리더만 접근할 수 있습니다."),
+    FORBIDDEN_STUDY_MEMBER_ONLY(HttpStatus.FORBIDDEN, "FORBIDDEN_STUDY_MEMBER_ONLY",
+        "스터디 멤버만 접근할 수 있습니다."),
+    FORBIDDEN_OWNER_OR_LEADER_ONLY(HttpStatus.FORBIDDEN, "FORBIDDEN_OWNER_OR_LEADER_ONLY",
+        "소유자 또는 스터디 리더만 접근할 수 있습니다."),
 
 
     // Validation
-    INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_NICKNAME_FORMAT", "닉네임 형식이 올바르지 않습니다."),
+    INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_NICKNAME_FORMAT",
+        "닉네임 형식이 올바르지 않습니다."),
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_EMAIL_FORMAT", "이메일 형식이 올바르지 않습니다."),
     INVALID_MAX_MEMBERS(HttpStatus.BAD_REQUEST, "INVALID_MAX_MEMBERS", "최대 멤버 수가 올바르지 않습니다."),
     INVALID_ROLE(HttpStatus.BAD_REQUEST, "INVALID_ROLE", "역할이 올바르지 않습니다."),
-    INVALID_MATERIAL_CATEGORY(HttpStatus.BAD_REQUEST, "INVALID_MATERIAL_CATEGORY", "자료 카테고리가 올바르지 않습니다."),
-    INVALID_MATERIAL_WEEK_REQUIRED(HttpStatus.BAD_REQUEST, "INVALID_MATERIAL_WEEK_REQUIRED", "학습자료에는 주차 정보가 필수입니다."),
-    INVALID_MATERIAL_WEEK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "INVALID_MATERIAL_WEEK_NOT_ALLOWED", "학습자료가 아닌 카테고리에서는 주차를 설정할 수 없습니다."),
+    INVALID_MATERIAL_CATEGORY(HttpStatus.BAD_REQUEST, "INVALID_MATERIAL_CATEGORY",
+        "자료 카테고리가 올바르지 않습니다."),
+    INVALID_MATERIAL_WEEK_REQUIRED(HttpStatus.BAD_REQUEST, "INVALID_MATERIAL_WEEK_REQUIRED",
+        "학습자료에는 주차 정보가 필수입니다."),
+    INVALID_MATERIAL_WEEK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "INVALID_MATERIAL_WEEK_NOT_ALLOWED",
+        "학습자료가 아닌 카테고리에서는 주차를 설정할 수 없습니다."),
     INVALID_START_TIME(HttpStatus.BAD_REQUEST, "INVALID_START_TIME", "시작 시간이 올바르지 않습니다."),
     INVALID_CANDIDATE_DATES(HttpStatus.BAD_REQUEST, "INVALID_CANDIDATE_DATES", "가능 날짜가 올바르지 않습니다."),
 
@@ -46,7 +54,8 @@ public enum ErrorCode {
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_NOT_FOUND", "스터디를 찾을 수 없습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "멤버를 찾을 수 없습니다."),
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE_NOT_FOUND", "일정을 찾을 수 없습니다."),
-    PENDING_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "PENDING_SCHEDULE_NOT_FOUND", "승인 대기 중인 일정을 찾을 수 없습니다."),
+    PENDING_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "PENDING_SCHEDULE_NOT_FOUND",
+        "승인 대기 중인 일정을 찾을 수 없습니다."),
     INVALID_STATE_CHANGE(HttpStatus.CONFLICT, "INVALID_STATE_CHANGE", "상태 변경이 유효하지 않습니다."),
     ALREADY_CHECKED_IN(HttpStatus.CONFLICT, "ALREADY_CHECKED_IN", "이미 출석 체크되었습니다."),
     ALREADY_MEMBER(HttpStatus.CONFLICT, "ALREADY_MEMBER", "이미 스터디의 멤버입니다."),
@@ -56,7 +65,17 @@ public enum ErrorCode {
 
     // Material Domain
     MATERIAL_NOT_FOUND(HttpStatus.NOT_FOUND, "MATERIAL_NOT_FOUND", "자료를 찾을 수 없습니다."),
-    FORBIDDEN_MATERIAL_ACCESS(HttpStatus.FORBIDDEN, "FORBIDDEN_MATERIAL_ACCESS", "자료에 접근할 권한이 없습니다."),
+    FORBIDDEN_MATERIAL_ACCESS(HttpStatus.FORBIDDEN, "FORBIDDEN_MATERIAL_ACCESS",
+        "자료에 접근할 권한이 없습니다."),
+
+    // Reflection Domain
+    REFLECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "REFLECTION_NOT_FOUND", "회고를 찾을 수 없습니다."),
+    FORBIDDEN_REFLECTION_OWNER_ONLY(HttpStatus.FORBIDDEN, "FORBIDDEN_REFLECTION_OWNER_ONLY",
+        "본인만 수정/삭제할 수 있습니다."),
+    ALREADY_REFLECTED(HttpStatus.CONFLICT, "ALREADY_REFLECTED", "이미 해당 일정에 회고를 작성했습니다."),
+    INVALID_REFLECTION_SCORE(HttpStatus.BAD_REQUEST, "INVALID_REFLECTION_SCORE",
+        "점수는 1~5 사이여야 합니다."),
+
 
     // File/S3 Domain
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FILE_NOT_FOUND", "파일을 찾을 수 없습니다."),

--- a/src/main/java/com/pado/global/exception/common/ErrorCode.java
+++ b/src/main/java/com/pado/global/exception/common/ErrorCode.java
@@ -88,7 +88,6 @@ public enum ErrorCode {
 
     //Redis
     REDIS_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "REDIS_UNAVAILABLE", "Redis 연결에 실패했습니다.");
-
     public final HttpStatus status;
     public final String code;
     public final String message;

--- a/src/main/java/com/pado/global/exception/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/pado/global/exception/common/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.pado.global.exception.common;
 
 import com.pado.global.exception.dto.ErrorResponseDto;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -43,7 +44,7 @@ public class GlobalExceptionHandler {
         ErrorResponseDto body = ErrorResponseDto.of(code, code.message, errors, path(req));
         return ResponseEntity.status(code.status).body(body);
     }
-    
+
     @ExceptionHandler(HandlerMethodValidationException.class)
     public ResponseEntity<ErrorResponseDto> handleHandlerMethodValidation(
         HandlerMethodValidationException ex, WebRequest req) {
@@ -152,6 +153,24 @@ public class GlobalExceptionHandler {
         log.error("Internal error at {}: {}", path, ex.getMessage(), ex);
 
         ErrorCode code = ErrorCode.INTERNAL_ERROR;
+        ErrorResponseDto body = ErrorResponseDto.of(code, code.message, Collections.emptyList(),
+            path(req));
+        return ResponseEntity.status(code.status).body(body);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handleEntityNotFound(EntityNotFoundException ex,
+        WebRequest req) {
+        ErrorCode code = ErrorCode.ENTITY_NOT_FOUND;
+        ErrorResponseDto body = ErrorResponseDto.of(code, code.message, Collections.emptyList(),
+            path(req));
+        return ResponseEntity.status(code.status).body(body);
+    }
+
+    @ExceptionHandler(org.springframework.security.access.AccessDeniedException.class)
+    public ResponseEntity<ErrorResponseDto> handleAccessDenied(
+        org.springframework.security.access.AccessDeniedException ex, WebRequest req) {
+        ErrorCode code = ErrorCode.FORBIDDEN_REFLECTION_OWNER_ONLY;
         ErrorResponseDto body = ErrorResponseDto.of(code, code.message, Collections.emptyList(),
             path(req));
         return ResponseEntity.status(code.status).body(body);

--- a/src/main/java/com/pado/global/swagger/annotation/reflection/Api403ForbiddenReflectionOwnerError.java
+++ b/src/main/java/com/pado/global/swagger/annotation/reflection/Api403ForbiddenReflectionOwnerError.java
@@ -1,0 +1,36 @@
+package com.pado.global.swagger.annotation.reflection;
+
+import com.pado.global.exception.dto.ErrorResponseDto;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(responseCode = "403", description = "접근 권한 없음 (회고 작성자가 아닌 경우)",
+    content = @Content(
+        mediaType = "application/json",
+        schema = @Schema(implementation = ErrorResponseDto.class),
+        examples = @ExampleObject(
+            name = "권한 없음 예시",
+            value = """
+                {
+                  "code": "FORBIDDEN_REFLECTION_OWNER_ONLY",
+                  "message": "본인만 수정/삭제할 수 있습니다.",
+                  "errors": [],
+                  "timestamp": "2025-09-07T09:28:57.508Z",
+                  "path": "/api/reflections/1"
+                }
+                """
+        )
+    )
+)
+public @interface Api403ForbiddenReflectionOwnerError {
+
+}

--- a/src/main/java/com/pado/global/swagger/annotation/reflection/Api404ReflectionNotFoundError.java
+++ b/src/main/java/com/pado/global/swagger/annotation/reflection/Api404ReflectionNotFoundError.java
@@ -1,0 +1,36 @@
+package com.pado.global.swagger.annotation.reflection;
+
+import com.pado.global.exception.dto.ErrorResponseDto;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(responseCode = "404", description = "회고를 찾을 수 없음",
+    content = @Content(
+        mediaType = "application/json",
+        schema = @Schema(implementation = ErrorResponseDto.class),
+        examples = @ExampleObject(
+            name = "존재하지 않는 회고 예시",
+            value = """
+                {
+                  "code": "REFLECTION_NOT_FOUND",
+                  "message": "회고를 찾을 수 없습니다.",
+                  "errors": [],
+                  "timestamp": "2025-09-07T09:28:57.508Z",
+                  "path": "/api/reflections/999"
+                }
+                """
+        )
+    )
+)
+public @interface Api404ReflectionNotFoundError {
+
+}

--- a/src/test/java/com/pado/domain/reflection/service/ReflectionServiceImplTest.java
+++ b/src/test/java/com/pado/domain/reflection/service/ReflectionServiceImplTest.java
@@ -1,0 +1,208 @@
+package com.pado.domain.reflection.service;
+
+import com.pado.domain.reflection.dto.ReflectionCreateRequestDto;
+import com.pado.domain.reflection.entity.Reflection;
+import com.pado.domain.reflection.repository.ReflectionRepository;
+import com.pado.domain.schedule.repository.ScheduleRepository;
+import com.pado.domain.study.entity.Study;
+import com.pado.domain.study.entity.StudyMember;
+import com.pado.domain.study.repository.StudyMemberRepository;
+import com.pado.domain.study.repository.StudyRepository;
+import com.pado.domain.user.entity.User;
+import com.pado.global.exception.common.BusinessException;
+import com.pado.global.exception.common.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ReflectionServiceImplTest {
+
+    @InjectMocks
+    private ReflectionServiceImpl reflectionService;
+
+    @Mock
+    private ReflectionRepository reflectionRepository;
+    @Mock
+    private StudyRepository studyRepository;
+    @Mock
+    private StudyMemberRepository studyMemberRepository;
+    @Mock
+    private ScheduleRepository scheduleRepository;
+
+    private User author;
+    private User anotherMember;
+    private User nonMember;
+    private Study study;
+    private StudyMember authorMember;
+    private Reflection reflection;
+
+    @BeforeEach
+    void setUp() {
+        author = User.builder().nickname("author").build();
+        anotherMember = User.builder().nickname("anotherMember").build();
+        nonMember = User.builder().nickname("nonMember").build();
+        ReflectionTestUtils.setField(author, "id", 1L);
+        ReflectionTestUtils.setField(anotherMember, "id", 2L);
+        ReflectionTestUtils.setField(nonMember, "id", 3L);
+
+        study = Study.builder().title("Test Study").build();
+        ReflectionTestUtils.setField(study, "id", 10L);
+
+        authorMember = StudyMember.builder().user(author).study(study).build();
+        ReflectionTestUtils.setField(authorMember, "id", 100L);
+
+        reflection = Reflection.builder()
+            .study(study)
+            .studyMember(authorMember)
+            .learnedContent("배운 점")
+            .improvement("개선할 점")
+            .satisfactionScore(5)
+            .understandingScore(5)
+            .participationScore(5)
+            .build();
+        ReflectionTestUtils.setField(reflection, "id", 1000L);
+    }
+
+    @Test
+    @DisplayName("스터디 멤버가 회고를 성공적으로 생성한다.")
+    void createReflection_Success() {
+        // given
+        ReflectionCreateRequestDto request = new ReflectionCreateRequestDto(null, 5, 5, 5, "배운 점",
+            "개선할 점");
+        given(
+            studyMemberRepository.findByStudyIdAndUserId(study.getId(), author.getId())).willReturn(
+            Optional.of(authorMember));
+        given(studyRepository.findById(study.getId())).willReturn(Optional.of(study));
+        given(reflectionRepository.save(any(Reflection.class))).willReturn(reflection);
+
+        // when
+        reflectionService.createReflection(study.getId(), author, request);
+
+        // then
+        verify(reflectionRepository).save(any(Reflection.class));
+    }
+
+    @Test
+    @DisplayName("스터디 멤버가 아닐 경우 회고 생성에 실패한다.")
+    void createReflection_Fail_NotStudyMember() {
+        // given
+        ReflectionCreateRequestDto request = new ReflectionCreateRequestDto(null, 5, 5, 5, "배운 점",
+            "개선할 점");
+        given(studyMemberRepository.findByStudyIdAndUserId(study.getId(),
+            nonMember.getId())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(
+            () -> reflectionService.createReflection(study.getId(), nonMember, request))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY);
+    }
+
+    @Test
+    @DisplayName("회고 작성자가 본인의 회고를 수정하면 성공한다.")
+    void updateReflection_Success_ByOwner() {
+        // given
+        ReflectionCreateRequestDto request = new ReflectionCreateRequestDto(null, 4, 4, 4, "수정된 내용",
+            "수정된 내용");
+        given(reflectionRepository.findById(reflection.getId())).willReturn(
+            Optional.of(reflection));
+
+        // when
+        reflectionService.updateReflection(reflection.getId(), author, request);
+
+        // then
+        assertThat(reflection.getSatisfactionScore()).isEqualTo(4);
+        assertThat(reflection.getLearnedContent()).isEqualTo("수정된 내용");
+    }
+
+    @Test
+    @DisplayName("회고 작성자가 아닌 경우 회고 수정에 실패한다.")
+    void updateReflection_Fail_NotOwner() {
+        // given
+        ReflectionCreateRequestDto request = new ReflectionCreateRequestDto(null, 4, 4, 4, "수정된 내용",
+            "수정된 내용");
+        given(reflectionRepository.findById(reflection.getId())).willReturn(
+            Optional.of(reflection));
+
+        // when & then
+        assertThatThrownBy(
+            () -> reflectionService.updateReflection(reflection.getId(), anotherMember, request))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_REFLECTION_OWNER_ONLY);
+    }
+
+    @Test
+    @DisplayName("회고 작성자가 본인의 회고를 삭제하면 성공한다.")
+    void deleteReflection_Success_ByOwner() {
+        // given
+        given(reflectionRepository.findById(reflection.getId())).willReturn(
+            Optional.of(reflection));
+
+        // when
+        reflectionService.deleteReflection(reflection.getId(), author);
+
+        // then
+        verify(reflectionRepository).deleteById(reflection.getId());
+    }
+
+    @Test
+    @DisplayName("회고 작성자가 아닌 경우 회고 삭제에 실패한다.")
+    void deleteReflection_Fail_NotOwner() {
+        // given
+        given(reflectionRepository.findById(reflection.getId())).willReturn(
+            Optional.of(reflection));
+
+        // when & then
+        assertThatThrownBy(
+            () -> reflectionService.deleteReflection(reflection.getId(), anotherMember))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_REFLECTION_OWNER_ONLY);
+    }
+
+    @Test
+    @DisplayName("스터디 멤버는 다른 사람의 회고를 상세 조회할 수 있다.")
+    void getReflection_Success_ByAnotherMember() {
+        // given
+        given(reflectionRepository.findById(reflection.getId())).willReturn(
+            Optional.of(reflection));
+        StudyMember anotherStudyMember = StudyMember.builder().user(anotherMember).study(study)
+            .build();
+        given(studyMemberRepository.findByStudyIdAndUserId(study.getId(), anotherMember.getId()))
+            .willReturn(Optional.of(anotherStudyMember));
+        // when
+        reflectionService.getReflection(reflection.getId(), anotherMember);
+
+        // then
+        verify(reflectionRepository).findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("스터디 멤버가 아니면 회고 상세 조회에 실패한다.")
+    void getReflection_Fail_ByNonMember() {
+        // given
+        given(reflectionRepository.findById(reflection.getId())).willReturn(
+            Optional.of(reflection));
+        given(studyMemberRepository.findByStudyIdAndUserId(study.getId(),
+            nonMember.getId())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> reflectionService.getReflection(reflection.getId(), nonMember))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY);
+    }
+}


### PR DESCRIPTION
## ✨ 요약

> 스터디 회고(Reflection) 기능에 대한 CRUD API를 구현합니다. 회고 작성, 조회, 수정, 삭제 기능과 함께 멤버별 권한 처리, Swagger 문서화, 비즈니스 로직 테스트 코드를 포함합니다.

## 🔗 작업 내용

- reflection 도메인 CRUD API 구현 (회고 생성, 조회, 수정, 삭제) 
- 접근 권한(Authorization) 로직 추가
- 생성/조회: 스터디 멤버만 가능 
- 수정/삭제: 회고 작성자 본인만 가능 
- 비즈니스 요구사항에 따른 예외 처리 및 
- ErrorCode 추가 (REFLECTION_NOT_FOUND, FORBIDDEN_REFLECTION_OWNER_ONLY) 
- Swagger API 문서화를 통한 명세 작성 및 DTO 스키마 설명 추가 
- ReflectionService에 대한 단위 테스트 코드 작성 

## 💻 상세 구현 내용
모든 API에서 
@CurrentUser를 통해 현재 로그인한 사용자의 정보를 받아 서비스 계층으로 전달하도록 구현했습니다. 
서비스 계층에 checkStudyMember와 checkReflectionOwner 라는 private 메서드를 두어 권한 확인 로직을 캡슐화했습니다. 
스터디 멤버 확인: studyMemberRepository를 조회하여 현재 사용자가 해당 스터디의 멤버인지 확인하며, 멤버가 아닐 경우 FORBIDDEN_STUDY_MEMBER_ONLY 예외를 발생시킵니다. 
회고 작성자 확인: 수정/삭제 요청 시, 대상 Reflection 엔티티에 연결된 사용자의 ID와 현재 사용자의 ID를 비교하여 일치하지 않으면 FORBIDDEN_REFLECTION_OWNER_ONLY 예외를 발생시킵니다. 

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #73 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)