### PR TITLE
Fix: 개인별 현황판 조회 수정 및 logout 기능 추가

### DIFF
--- a/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
@@ -28,7 +28,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
-@Tag(name = "10. Attendance", description = "출석 관리 관련 API")
+@Tag(name = "14. Attendance", description = "출석 관리 관련 API")
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor

--- a/src/main/java/com/pado/domain/attendance/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/pado/domain/attendance/service/AttendanceServiceImpl.java
@@ -117,7 +117,7 @@ public class AttendanceServiceImpl implements AttendanceService {
             .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
 
         // 스터디 멤버 검증
-        if (!studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))) {
+        if (!studyMemberRepository.existsByStudyAndUser(study, user)) {
             throw new BusinessException(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY);
         }
 

--- a/src/main/java/com/pado/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/pado/domain/auth/controller/AuthController.java
@@ -114,6 +114,19 @@ public class AuthController {
             .body(new TokenResponseDto(tokens.accessToken()));
     }
 
+    @Operation(summary = "로그아웃", description = "Refresh 쿠키를 통해 Refreshtoken을 삭제시킵니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "성공", content = @Content),
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@CookieValue(value = "REFRESH_TOKEN", required = false) String refreshToken) {
+        if (refreshToken == null) {
+            throw new BusinessException(ErrorCode.UNAUTHENTICATED_USER, "RefreshToken 쿠키가 없습니다.");
+        }
+        authService.logout(refreshToken);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
     @Operation(summary = "액세스 토큰 재발급", description = "Refresh 쿠키로 Access 토큰을 재발급합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "성공",

--- a/src/main/java/com/pado/domain/auth/service/AuthService.java
+++ b/src/main/java/com/pado/domain/auth/service/AuthService.java
@@ -28,4 +28,6 @@ public interface AuthService {
 
     //accesstoken 재발급
     TokenResponseDto renewAccessToken(String refreshToken);
+
+    void logout(String refreshToken);
 }

--- a/src/main/java/com/pado/domain/progress/dto/ProgressChapterDto.java
+++ b/src/main/java/com/pado/domain/progress/dto/ProgressChapterDto.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "스터디 로드맵 차시별 DTO")
 public record ProgressChapterDto (
         @Schema(description = "차시 별 로드맵 내용", example = "1차시에 진행할 내용입니다")
-        String content
+        String content,
+        @Schema(description = "차시 별 로드맵 완료 여부", example = "True")
+        boolean completed
 ){
 }

--- a/src/main/java/com/pado/domain/progress/dto/ProgressMemberStatusDto.java
+++ b/src/main/java/com/pado/domain/progress/dto/ProgressMemberStatusDto.java
@@ -9,20 +9,11 @@ public record ProgressMemberStatusDto(
         String nickname,
         @Schema(description = "스터디에서의 역할", example = "Leader", allowableValues = {"Leader", "Member", "Pending"})
         StudyMemberRole role,
-
         @Schema(description = "출석 횟수", example = "5")
         int attendance_count,
-        @Schema(description = "총 출석 횟수", example = "10")
-        int attendance_total,
-
         @Schema(description = "퀴즈 횟수", example = "8")
         int quiz_count,
-        @Schema(description = "총 퀴즈 횟수", example = "10")
-        int quiz_total,
-
         @Schema(description = "회고 횟수", example = "3")
-        int reflection_count,
-        @Schema(description = "총 회고 횟수", example = "10")
-        int reflection_total
+        int reflection_count
 ){
 }

--- a/src/main/java/com/pado/domain/progress/service/ProgressServiceImpl.java
+++ b/src/main/java/com/pado/domain/progress/service/ProgressServiceImpl.java
@@ -28,14 +28,13 @@ public class ProgressServiceImpl implements ProgressService {
     private final StudyRepository studyRepository;
     private final StudyMemberRepository studyMemberRepository;
     private final AttendanceRepository attendanceRepository;
-    private final ScheduleRepository scheduleRepository;
 
     @Override
     public ProgressRoadMapResponseDto getRoadMap(Long studyId, User user) {
         checkException(studyId, user, StudyMemberRole.MEMBER);
         List<Chapter> chapters = chapterRepository.findByStudyId(studyId);
         List<ProgressChapterDto> progressChapterDtos = chapters.stream().map(
-                chapter -> new ProgressChapterDto(chapter.getContent()))
+                chapter -> new ProgressChapterDto(chapter.getContent(), chapter.isCompleted()))
                 .toList();
 
         return new ProgressRoadMapResponseDto(progressChapterDtos);
@@ -88,13 +87,10 @@ public class ProgressServiceImpl implements ProgressService {
 
         List<StudyMember> studyMembers = studyMemberRepository.findByStudyIdFetchUser(studyId);
         Map<Long, Long> attendanceCountMap = attendanceRepository.countMapByStudy(studyId);
-        int attendanceTotal = scheduleRepository.countAllByStudyId(studyId);
 
         // quiz와 reflection 구현되면 수정
         int quizCount = 5;
-        int quizTotal = 10;
         int reflectionCount = 3;
-        int reflectionTotal = attendanceTotal;
 
 
         List<ProgressMemberStatusDto> progressMemberStatusDtos =  studyMembers.stream().map(
@@ -102,11 +98,8 @@ public class ProgressServiceImpl implements ProgressService {
                         studyMember.getUser().getNickname(),
                         studyMember.getRole(),
                         Math.toIntExact(attendanceCountMap.getOrDefault(studyMember.getUser().getId(), 0L)),
-                        attendanceTotal,
                         quizCount,
-                        quizTotal,
-                        reflectionCount,
-                        reflectionTotal
+                        reflectionCount
                         )
         ).toList();
         return new ProgressStatusResponseDto(progressMemberStatusDtos);

--- a/src/main/java/com/pado/domain/progress/service/ProgressServiceImpl.java
+++ b/src/main/java/com/pado/domain/progress/service/ProgressServiceImpl.java
@@ -4,6 +4,10 @@ import com.pado.domain.attendance.repository.AttendanceRepository;
 import com.pado.domain.progress.dto.*;
 import com.pado.domain.progress.entity.Chapter;
 import com.pado.domain.progress.repository.ChapterRepository;
+import com.pado.domain.quiz.entity.Quiz;
+import com.pado.domain.quiz.repository.QuizSubmissionRepository;
+import com.pado.domain.reflection.entity.Reflection;
+import com.pado.domain.reflection.repository.ReflectionRepository;
 import com.pado.domain.schedule.repository.ScheduleRepository;
 import com.pado.domain.study.entity.Study;
 import com.pado.domain.study.entity.StudyMember;
@@ -28,6 +32,8 @@ public class ProgressServiceImpl implements ProgressService {
     private final StudyRepository studyRepository;
     private final StudyMemberRepository studyMemberRepository;
     private final AttendanceRepository attendanceRepository;
+    private final QuizSubmissionRepository quizSubmissionRepository;
+    private final ReflectionRepository reflectionRepository;
 
     @Override
     public ProgressRoadMapResponseDto getRoadMap(Long studyId, User user) {
@@ -87,19 +93,18 @@ public class ProgressServiceImpl implements ProgressService {
 
         List<StudyMember> studyMembers = studyMemberRepository.findByStudyIdFetchUser(studyId);
         Map<Long, Long> attendanceCountMap = attendanceRepository.countMapByStudy(studyId);
+        Map<Long, Long> quizCountMap = quizSubmissionRepository.countMapByStudy(studyId);
+        Map<Long, Long> reflectionCountMap = reflectionRepository.countMapByStudy(studyId);
 
-        // quiz와 reflection 구현되면 수정
-        int quizCount = 5;
-        int reflectionCount = 3;
+        List<Reflection> reflections = reflectionRepository.findByStudyId(studyId);
 
-
-        List<ProgressMemberStatusDto> progressMemberStatusDtos =  studyMembers.stream().map(
+        List<ProgressMemberStatusDto> progressMemberStatusDtos = studyMembers.stream().map(
                 studyMember -> new ProgressMemberStatusDto(
                         studyMember.getUser().getNickname(),
                         studyMember.getRole(),
                         Math.toIntExact(attendanceCountMap.getOrDefault(studyMember.getUser().getId(), 0L)),
-                        quizCount,
-                        reflectionCount
+                        Math.toIntExact(quizCountMap.getOrDefault(studyMember.getUser().getId(), 0L)),
+                        Math.toIntExact(reflectionCountMap.getOrDefault(studyMember.getUser().getId(), 0L))
                         )
         ).toList();
         return new ProgressStatusResponseDto(progressMemberStatusDtos);

--- a/src/main/java/com/pado/domain/quiz/repository/QuizSubmissionRepository.java
+++ b/src/main/java/com/pado/domain/quiz/repository/QuizSubmissionRepository.java
@@ -12,23 +12,4 @@ import java.util.stream.Collectors;
 
 public interface QuizSubmissionRepository extends JpaRepository<QuizSubmission, Long>, QuizSubmissionRepositoryCustom {
     Optional<QuizSubmission> findByQuizIdAndUserId(Long quizId, Long userId);
-
-    interface UserQuizCount {
-        Long getUserId();
-        Long getCnt();
-    }
-
-    @Query("""
-                select qs.user.id as userId, count(qs) as cnt
-                from QuizSubmission qs
-                where qs.quiz.study.id = :studyId
-                group by qs.user.id
-            """
-    )
-    List<UserQuizCount> countByStudyGroupByUser(@Param("studyId") Long studyId);
-
-    default Map<Long, Long> countMapByStudy(Long studyId) {
-        return countByStudyGroupByUser(studyId).stream()
-                .collect(Collectors.toMap(UserQuizCount::getUserId, UserQuizCount::getCnt));
-    }
 }

--- a/src/main/java/com/pado/domain/quiz/repository/QuizSubmissionRepository.java
+++ b/src/main/java/com/pado/domain/quiz/repository/QuizSubmissionRepository.java
@@ -2,9 +2,33 @@ package com.pado.domain.quiz.repository;
 
 import com.pado.domain.quiz.entity.QuizSubmission;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public interface QuizSubmissionRepository extends JpaRepository<QuizSubmission, Long>, QuizSubmissionRepositoryCustom {
     Optional<QuizSubmission> findByQuizIdAndUserId(Long quizId, Long userId);
+
+    interface UserQuizCount {
+        Long getUserId();
+        Long getCnt();
+    }
+
+    @Query("""
+                select qs.user.id as userId, count(qs) as cnt
+                from QuizSubmission qs
+                where qs.quiz.study.id = :studyId
+                group by qs.user.id
+            """
+    )
+    List<UserQuizCount> countByStudyGroupByUser(@Param("studyId") Long studyId);
+
+    default Map<Long, Long> countMapByStudy(Long studyId) {
+        return countByStudyGroupByUser(studyId).stream()
+                .collect(Collectors.toMap(UserQuizCount::getUserId, UserQuizCount::getCnt));
+    }
 }

--- a/src/main/java/com/pado/domain/quiz/repository/QuizSubmissionRepositoryCustom.java
+++ b/src/main/java/com/pado/domain/quiz/repository/QuizSubmissionRepositoryCustom.java
@@ -2,11 +2,19 @@ package com.pado.domain.quiz.repository;
 
 import com.pado.domain.quiz.dto.projection.SubmissionStatusDto;
 import com.pado.domain.quiz.entity.QuizSubmission;
+import com.pado.domain.quiz.repository.dto.UserQuizCountDto;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public interface QuizSubmissionRepositoryCustom {
     List<SubmissionStatusDto> findSubmissionStatuses(List<Long> quizIds, Long userId);
     Optional<QuizSubmission> findWithDetailsById(Long submissionId);
+    List<UserQuizCountDto> countByStudyGroupByUser(Long studyId);
+    default Map<Long, Long> countMapByStudy(Long studyId) {
+        return countByStudyGroupByUser(studyId).stream()
+                .collect(Collectors.toMap(UserQuizCountDto::userId, UserQuizCountDto::cnt));
+    }
 }

--- a/src/main/java/com/pado/domain/quiz/repository/QuizSubmissionRepositoryImpl.java
+++ b/src/main/java/com/pado/domain/quiz/repository/QuizSubmissionRepositoryImpl.java
@@ -2,7 +2,10 @@ package com.pado.domain.quiz.repository;
 
 import com.pado.domain.quiz.dto.projection.QSubmissionStatusDto;
 import com.pado.domain.quiz.dto.projection.SubmissionStatusDto;
+import com.pado.domain.quiz.entity.QQuizSubmission;
 import com.pado.domain.quiz.entity.QuizSubmission;
+import com.pado.domain.quiz.repository.dto.UserQuizCountDto;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -47,5 +50,19 @@ public class QuizSubmissionRepositoryImpl implements QuizSubmissionRepositoryCus
                 .fetchOne();
 
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public List<UserQuizCountDto> countByStudyGroupByUser(Long studyId) {
+        QQuizSubmission qs = QQuizSubmission.quizSubmission;
+
+        return queryFactory
+                .select(Projections.constructor(UserQuizCountDto.class,
+                        qs.user.id,
+                        qs.count())) // count(qs)
+                .from(qs)
+                .where(qs.quiz.study.id.eq(studyId))
+                .groupBy(qs.user.id)
+                .fetch();
     }
 }

--- a/src/main/java/com/pado/domain/quiz/repository/dto/UserQuizCountDto.java
+++ b/src/main/java/com/pado/domain/quiz/repository/dto/UserQuizCountDto.java
@@ -1,0 +1,3 @@
+package com.pado.domain.quiz.repository.dto;
+
+public record UserQuizCountDto(Long userId, Long cnt) {}

--- a/src/main/java/com/pado/domain/reflection/repository/ReflectionRepository.java
+++ b/src/main/java/com/pado/domain/reflection/repository/ReflectionRepository.java
@@ -2,9 +2,32 @@ package com.pado.domain.reflection.repository;
 
 import com.pado.domain.reflection.entity.Reflection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public interface ReflectionRepository extends JpaRepository<Reflection, Long> {
 
     List<Reflection> findByStudyId(Long studyId);
+
+    interface UserReflectionCount{
+        Long getStudyMemberId();
+        Long getCnt();
+    }
+
+    @Query("""
+        select sm.id as studyMemberId, count(r) as cnt 
+        from Reflection r
+        join r.studyMember sm
+        where r.study.id = :studyId 
+        group by sm.id         
+    """)
+    List<UserReflectionCount> countByStudyGroupByStudyMember(@Param("studyId") Long studyId);
+
+    default Map<Long, Long> countMapByStudy(Long studyId){
+        return countByStudyGroupByStudyMember(studyId).stream()
+                .collect(Collectors.toMap(UserReflectionCount::getStudyMemberId, UserReflectionCount::getCnt));
+    }
 }

--- a/src/main/java/com/pado/domain/reflection/repository/ReflectionRepositoryCustom.java
+++ b/src/main/java/com/pado/domain/reflection/repository/ReflectionRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.pado.domain.reflection.repository;
+
+import com.pado.domain.reflection.repository.dto.UserReflectionCountDto;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public interface ReflectionRepositoryCustom {
+    List<UserReflectionCountDto> countByStudyGroupByStudyMember(Long studyId);
+
+    default Map<Long, Long> countMapByStudy(Long studyId) {
+        return countByStudyGroupByStudyMember(studyId).stream()
+                .collect(Collectors.toMap(UserReflectionCountDto::studyMemberId, UserReflectionCountDto::cnt));
+    }
+}

--- a/src/main/java/com/pado/domain/reflection/repository/ReflectionRepositoryImpl.java
+++ b/src/main/java/com/pado/domain/reflection/repository/ReflectionRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.pado.domain.reflection.repository;
+
+import com.pado.domain.reflection.entity.QReflection;
+import com.pado.domain.reflection.repository.dto.UserReflectionCountDto;
+import com.pado.domain.study.entity.QStudyMember;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReflectionRepositoryImpl implements ReflectionRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<UserReflectionCountDto> countByStudyGroupByStudyMember(Long studyId) {
+        QReflection r = QReflection.reflection;
+        QStudyMember sm = QStudyMember.studyMember;
+
+        return queryFactory
+                .select(Projections.constructor(UserReflectionCountDto.class,
+                        sm.id,
+                        r.count()))
+                .from(r)
+                .join(r.studyMember, sm)
+                .where(r.study.id.eq(studyId))
+                .groupBy(sm.id)
+                .fetch();
+    }
+}

--- a/src/main/java/com/pado/domain/reflection/repository/dto/UserReflectionCountDto.java
+++ b/src/main/java/com/pado/domain/reflection/repository/dto/UserReflectionCountDto.java
@@ -1,0 +1,3 @@
+package com.pado.domain.reflection.repository.dto;
+
+public record UserReflectionCountDto(Long studyMemberId, Long cnt) { }

--- a/src/test/java/com/pado/domain/attendance/service/AttendanceServiceImplTest.java
+++ b/src/test/java/com/pado/domain/attendance/service/AttendanceServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.pado.domain.attendance.service;
 
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 import static org.mockito.ArgumentMatchers.any;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,48 +56,47 @@ class AttendanceServiceImplTest {
 
     private User testUser(Long id) {
         User u = User.builder()
-            .email("test@test.com")
-            .passwordHash("hashed")
-            .nickname("tester")
-            .region(Region.SEOUL)
-            .gender(Gender.MALE)
-            .build();
+                .email("test@test.com")
+                .passwordHash("hashed")
+                .nickname("tester")
+                .region(Region.SEOUL)
+                .gender(Gender.MALE)
+                .build();
         ReflectionTestUtils.setField(u, "id", id);
         return u;
     }
 
     private User testUser(Long id, String name) {
         User u = User.builder()
-            .email("test@test.com")
-            .passwordHash("hashed")
-            .nickname(name)
-            .region(Region.SEOUL)
-            .gender(Gender.MALE)
-            .build();
+                .email("test@test.com")
+                .passwordHash("hashed")
+                .nickname(name)
+                .region(Region.SEOUL)
+                .gender(Gender.MALE)
+                .build();
         ReflectionTestUtils.setField(u, "id", id);
         return u;
     }
 
     private Schedule testSchedule(Long id, Long studyId, LocalDateTime startDate) {
-        Schedule s = Schedule.builder()
-            .studyId(studyId)
-            .title("스터디 일정")
-            .description("설명")
-            .startTime(startDate)
-            .endTime(startDate.plusDays(1))
-            .build();
+        Schedule s =  Schedule.builder()
+                .studyId(studyId)
+                .title("스터디 일정")
+                .description("설명")
+                .startTime(startDate)
+                .endTime(startDate.plusDays(1))
+                .build();
         ReflectionTestUtils.setField(s, "id", id);
         return s;
     }
-
     private Schedule testSchedule(Long studyId) {
         return Schedule.builder()
-            .studyId(studyId)
-            .title("스터디 일정")
-            .description("설명")
-            .startTime(LocalDateTime.now())
-            .endTime(LocalDateTime.now().plusHours(2))
-            .build();
+                .studyId(studyId)
+                .title("스터디 일정")
+                .description("설명")
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now().plusHours(2))
+                .build();
     }
 
     private Study testStudy(Long id) {
@@ -105,21 +105,21 @@ class AttendanceServiceImplTest {
 
     private Attendance testAttendance(Long id, Schedule schedule, User user, boolean status) {
         Attendance a = Attendance.builder()
-            .schedule(schedule)
-            .user(user)
-            .status(status)
-            .checkInTime(LocalDateTime.now())
-            .build();
+                .schedule(schedule)
+                .user(user)
+                .status(status)
+                .checkInTime(LocalDateTime.now())
+                .build();
         ReflectionTestUtils.setField(a, "id", id);
         return a;
     }
 
     private StudyMember testStudyMember(Study study, User user, StudyMemberRole role) {
         return StudyMember.builder()
-            .study(study)
-            .user(user)
-            .role(role)
-            .build();
+                .study(study)
+                .user(user)
+                .role(role)
+                .build();
     }
 
     @Test
@@ -133,8 +133,8 @@ class AttendanceServiceImplTest {
 
         // when & then
         assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
-            .isInstanceOf(BusinessException.class)
-            .hasMessageContaining(ErrorCode.SCHEDULE_NOT_FOUND.message);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.SCHEDULE_NOT_FOUND.message);
     }
 
     @Test
@@ -147,13 +147,14 @@ class AttendanceServiceImplTest {
         User user = testUser(userId);
         Schedule schedule = testSchedule(studyId);
 
+
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
         given(studyRepository.findById(studyId)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
-            .isInstanceOf(BusinessException.class)
-            .hasMessageContaining(ErrorCode.STUDY_NOT_FOUND.message);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.STUDY_NOT_FOUND.message);
     }
 
     @Test
@@ -169,12 +170,12 @@ class AttendanceServiceImplTest {
 
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
         given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
-        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(false);
+        given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(false);
 
         // when & then
         assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
-            .isInstanceOf(BusinessException.class)
-            .hasMessageContaining(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY.message);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY.message);
     }
 
     @Test
@@ -190,13 +191,13 @@ class AttendanceServiceImplTest {
 
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
         given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
-        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(true);
+        given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(true);
         given(attendanceRepository.existsByScheduleAndUser(schedule, user)).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
-            .isInstanceOf(BusinessException.class)
-            .hasMessageContaining(ErrorCode.ALREADY_CHECKED_IN.message);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.ALREADY_CHECKED_IN.message);
     }
 
     @Test
@@ -211,7 +212,7 @@ class AttendanceServiceImplTest {
 
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
         given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
-        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(true);
+        given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(true);
         given(attendanceRepository.existsByScheduleAndUser(schedule, user)).willReturn(false);
 
         // when
@@ -225,7 +226,7 @@ class AttendanceServiceImplTest {
 
     @Test
     @DisplayName("출석한 경우 개별 출석 여부 확인")
-    void 개별_출석_확인_출석() {
+    void 개별_출석_확인_출석(){
         // given
         Long userId = 10L;
         Long scheduleId = 1L;
@@ -236,11 +237,10 @@ class AttendanceServiceImplTest {
 
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
         given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
-        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(true);
+        given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(true);
         given(attendanceRepository.existsByScheduleAndUser(schedule, user)).willReturn(true);
 
-        AttendanceStatusResponseDto response = attendanceService.getIndividualAttendanceStatus(
-            scheduleId, user);
+        AttendanceStatusResponseDto response = attendanceService.getIndividualAttendanceStatus(scheduleId, user);
         assertThat(response).isNotNull();
         assertThat(response.status()).isTrue();
         then(attendanceRepository).should(times(0)).save(any(Attendance.class));
@@ -248,7 +248,7 @@ class AttendanceServiceImplTest {
 
     @Test
     @DisplayName("미출석한 경우 개별 출석 여부 확인")
-    void 개별_출석_확인_미출석() {
+    void 개별_출석_확인_미출석(){
         // given
         Long userId = 10L;
         Long scheduleId = 1L;
@@ -259,11 +259,10 @@ class AttendanceServiceImplTest {
 
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
         given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
-        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(true);
+        given(studyMemberRepository.existsByStudyAndUser(study, user)).willReturn(true);
         given(attendanceRepository.existsByScheduleAndUser(schedule, user)).willReturn(false);
 
-        AttendanceStatusResponseDto response = attendanceService.getIndividualAttendanceStatus(
-            scheduleId, user);
+        AttendanceStatusResponseDto response = attendanceService.getIndividualAttendanceStatus(scheduleId, user);
         assertThat(response).isNotNull();
         assertThat(response.status()).isFalse();
         then(attendanceRepository).should(times(0)).save(any(Attendance.class));
@@ -283,22 +282,22 @@ class AttendanceServiceImplTest {
         StudyMember sm2 = testStudyMember(study, u2, StudyMemberRole.LEADER);
         List<StudyMember> members = List.of(sm1, sm2);
 
+        // 스케줄 3개 (시간순 정렬 가정)
         LocalDateTime base = LocalDateTime.now().withNano(0);
         Schedule sc1 = testSchedule(11L, studyId, base.plusDays(1));
         Schedule sc2 = testSchedule(12L, studyId, base.plusDays(2));
         Schedule sc3 = testSchedule(13L, studyId, base.plusDays(3));
         List<Schedule> schedules = List.of(sc1, sc2, sc3);
 
+        // Attendance: u1은 sc1만 출석(true)
         Attendance a1 = testAttendance(1000L, sc1, u1, true);
         List<Attendance> attendanceList = List.of(a1);
 
         given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
         given(studyMemberRepository.findByStudyWithUser(study)).willReturn(members);
         given(scheduleRepository.findByStudyIdOrderByStartTimeAsc(studyId)).willReturn(schedules);
-        given(attendanceRepository.findAllByStudyIdWithScheduleAndUser(studyId)).willReturn(
-            attendanceList);
-        given(studyMemberRepository.findLeaderUserIdByStudy(study,
-            StudyMemberRole.LEADER)).willReturn(u2.getId());
+        given(attendanceRepository.findAllByStudyIdWithScheduleAndUser(studyId)).willReturn(attendanceList);
+        given(studyMemberRepository.findLeaderUserIdByStudy(study, StudyMemberRole.LEADER)).willReturn(u2.getId());
 
         // when
         AttendanceListResponseDto resp = attendanceService.getFullAttendance(studyId);
@@ -306,23 +305,33 @@ class AttendanceServiceImplTest {
         // then
         assertThat(resp).isNotNull();
 
+        // record 스타일 가정: members()
         List<MemberAttendanceDto> resultMembers = resp.members();
         assertThat(resultMembers).hasSize(2);
 
+        // 멤버별 상태 길이는 스케줄 개수와 동일해야 함
         MemberAttendanceDto m1 = resultMembers.get(0);
         MemberAttendanceDto m2 = resultMembers.get(1);
 
         assertThat(m1.attendance()).hasSize(3);
         assertThat(m2.attendance()).hasSize(3);
+
+        // u2: [false, false, false], 리더가 먼저 출력되는지 확인
         assertThat(m1.name()).isEqualTo("u2");
         assertThat(m1.attendance().stream().allMatch(s -> !s.status())).isTrue();
+
+
+        // u1: [true, false, false]
         assertThat(m2.name()).isEqualTo("u1");
         assertThat(m2.attendance().get(0).status()).isTrue();
         assertThat(m2.attendance().get(1).status()).isFalse();
         assertThat(m2.attendance().get(2).status()).isFalse();
+
+        // 스케줄 시간 정렬 보장 체크
         assertThat(m1.attendance().get(0).schedule_date()).isEqualTo(sc1.getStartTime());
         assertThat(m1.attendance().get(1).schedule_date()).isEqualTo(sc2.getStartTime());
         assertThat(m1.attendance().get(2).schedule_date()).isEqualTo(sc3.getStartTime());
+
 
         then(studyRepository).should(times(1)).findById(studyId);
         then(studyMemberRepository).should(times(1)).findByStudyWithUser(study);

--- a/src/test/java/com/pado/domain/progress/service/ProgressServiceImplTest.java
+++ b/src/test/java/com/pado/domain/progress/service/ProgressServiceImplTest.java
@@ -2,10 +2,13 @@ package com.pado.domain.progress.service;
 
 import com.pado.domain.attendance.repository.AttendanceRepository;
 import com.pado.domain.progress.dto.ProgressChapterRequestDto;
+import com.pado.domain.progress.dto.ProgressMemberStatusDto;
 import com.pado.domain.progress.dto.ProgressRoadMapResponseDto;
 import com.pado.domain.progress.dto.ProgressStatusResponseDto;
 import com.pado.domain.progress.entity.Chapter;
 import com.pado.domain.progress.repository.ChapterRepository;
+import com.pado.domain.quiz.repository.QuizSubmissionRepository;
+import com.pado.domain.reflection.repository.ReflectionRepository;
 import com.pado.domain.schedule.repository.ScheduleRepository;
 import com.pado.domain.shared.entity.Region;
 import com.pado.domain.study.entity.Study;
@@ -28,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -41,6 +45,8 @@ class ProgressServiceImplTest {
     @Mock StudyMemberRepository studyMemberRepository;
     @Mock AttendanceRepository attendanceRepository;
     @Mock ScheduleRepository scheduleRepository;
+    @Mock QuizSubmissionRepository quizSubmissionRepository;
+    @Mock ReflectionRepository reflectionRepository;
 
     @InjectMocks ProgressServiceImpl service;
 
@@ -307,7 +313,7 @@ class ProgressServiceImplTest {
     // ---------- getStudyStatus ----------
 
     @Test
-    void getStudyStatus_멤버권한일때_개인진척도리스트반환() {
+    void getStudyStatus_멤버권한일때_개인진척도리스트반환_모든지표검증() {
         // given
         User u1 = mock(User.class); when(u1.getId()).thenReturn(1L); when(u1.getNickname()).thenReturn("철수");
         User u2 = mock(User.class); when(u2.getId()).thenReturn(2L); when(u2.getNickname()).thenReturn("영희");
@@ -324,8 +330,14 @@ class ProgressServiceImplTest {
         given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(eq(studyId), eq(userMember.getId()), anyCollection()))
                 .willReturn(true);
         given(studyMemberRepository.findByStudyIdFetchUser(studyId)).willReturn(List.of(sm1, sm2));
-        given(attendanceRepository.countMapByStudy(studyId)).willReturn(Map.of(1L, 3L)); // u1만 3회
-        given(scheduleRepository.countAllByStudyId(studyId)).willReturn(5);
+
+        // 핵심: 모든 맵 스텁
+        given(attendanceRepository.countMapByStudy(studyId)).willReturn(Map.of(1L, 3L));  // 철수=3, 영희=0
+        given(quizSubmissionRepository.countMapByStudy(studyId)).willReturn(Map.of(1L, 2L, 2L, 1L)); // 철수=2, 영희=1
+        given(reflectionRepository.countMapByStudy(studyId)).willReturn(Collections.emptyMap()); // 둘 다 0
+
+        // findByStudyId(Reflection) 호출된다면(현재 미사용) 안전하게 빈 컬렉션 리턴
+        given(reflectionRepository.findByStudyId(studyId)).willReturn(Collections.emptyList());
 
         // when
         ProgressStatusResponseDto dto = service.getStudyStatus(studyId, userMember);
@@ -333,10 +345,24 @@ class ProgressServiceImplTest {
         // then
         assertNotNull(dto);
         assertEquals(2, dto.progressMemberStatusDto().size());
-        // 철수 = 3, 영희 = 기본 0
-        assertEquals(3, dto.progressMemberStatusDto().get(0).attendance_count());
-        assertEquals(0, dto.progressMemberStatusDto().get(1).attendance_count());
+
+        // 순서 의존 제거: 닉네임으로 매핑
+        Map<String, ProgressMemberStatusDto> byName = dto.progressMemberStatusDto().stream()
+                .collect(Collectors.toMap(ProgressMemberStatusDto::nickname, d -> d));
+
+        assertEquals(StudyMemberRole.MEMBER, byName.get("철수").role());
+        assertEquals(StudyMemberRole.LEADER, byName.get("영희").role());
+
+        assertEquals(3, byName.get("철수").attendance_count());
+        assertEquals(0, byName.get("영희").attendance_count());
+
+        assertEquals(2, byName.get("철수").quiz_count());
+        assertEquals(1, byName.get("영희").quiz_count());
+
+        assertEquals(0, byName.get("철수").reflection_count());
+        assertEquals(0, byName.get("영희").reflection_count());
     }
+
 
     @Test
     void getStudyStatus_권한없음_예외_FORBIDDEN_STUDY_MEMBER_ONLY() {


### PR DESCRIPTION
## ✨ 요약

개인별 현황판에서 조회 기능을 수정하고 logout api를 추가했습니다.

## 🔗 작업 내용

- logout api 추가
- attendance swagger 번호 수정
- 진척도 현황판 dto 수정,  quiz, reflection 반영한 service 로직 추가

## 💻 상세 구현 내용

-attendance
출석 관련 swagger 14번으로 수정

- auth
logout api authcontroller에 추가
logout 로직 authserviceImpl에 추가

-progress
quizsubmissionrepository, reflectionrepository에 studyid를 통해 userid와 user가 참여한 횟수를 map으로 받을 수 있는 메서드 구현  
progressservice에 quiz, reflection 반영한 결과 추가
progressserviceTest로 정상작동 확인

## 🔗 참고 사항

logout 시 올바르지 않은 입력이어도 공격자에게 정보를 주지 않기 위해 성공적으로 로그아웃 된 것으로 출력됩니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #106

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)