### PR TITLE
Feat: 출석 기능에서 참가 기능으로 로직 변경 및 추가

### DIFF
--- a/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
@@ -1,18 +1,19 @@
 package com.pado.domain.attendance.controller;
 
-import com.pado.domain.attendance.dto.*;
+import com.pado.domain.attendance.dto.AttendanceListResponseDto;
+import com.pado.domain.attendance.dto.AttendanceMemberStatusRequestDto;
+import com.pado.domain.attendance.dto.AttendanceStatusRequestDto;
+import com.pado.domain.attendance.dto.AttendanceStatusResponseDto;
 import com.pado.domain.attendance.service.AttendanceService;
 import com.pado.domain.user.entity.User;
 import com.pado.global.auth.annotation.CurrentUser;
-import com.pado.global.exception.dto.ErrorResponseDto;
-import com.pado.global.swagger.annotation.study.Api403ForbiddenStudyMemberOnlyError;
 import com.pado.global.swagger.annotation.schedule.Api404ScheduleNotFoundError;
+import com.pado.global.swagger.annotation.study.Api403ForbiddenStudyMemberOnlyError;
 import com.pado.global.swagger.annotation.study.Api404StudyNotFoundError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -22,9 +23,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.net.ssl.HttpsURLConnection;
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.List;
 
 @Tag(name = "14. Attendance", description = "출석 관리 관련 API")
 @RestController

--- a/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/pado/domain/attendance/controller/AttendanceController.java
@@ -1,9 +1,6 @@
 package com.pado.domain.attendance.controller;
 
-import com.pado.domain.attendance.dto.AttendanceListResponseDto;
-import com.pado.domain.attendance.dto.AttendanceStatusDto;
-import com.pado.domain.attendance.dto.AttendanceStatusResponseDto;
-import com.pado.domain.attendance.dto.MemberAttendanceDto;
+import com.pado.domain.attendance.dto.*;
 import com.pado.domain.attendance.service.AttendanceService;
 import com.pado.domain.user.entity.User;
 import com.pado.global.auth.annotation.CurrentUser;
@@ -24,11 +21,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.net.ssl.HttpsURLConnection;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
-@Tag(name = "10. Attendance", description = "출석 관리 관련 API")
+@Tag(name = "14. Attendance", description = "출석 관리 관련 API")
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -49,7 +47,7 @@ public class AttendanceController {
     @Parameters({
         @Parameter(name = "study_id", description = "참여 현황을 조회할 스터디의 ID", required = true, example = "1")
     })
-    @GetMapping("/studies/{study_id}/attendance")
+    @GetMapping("/studies/{study_id}/attendances")
     public ResponseEntity<AttendanceListResponseDto> getFullAttendance(
         @PathVariable("study_id") Long studyId
     ) {
@@ -69,51 +67,80 @@ public class AttendanceController {
     @Parameters({
         @Parameter(name = "schedule_id", description = "출석 상태를 조회할 일정의 ID", required = true, example = "1234")
     })
-    @GetMapping("schedules/{scheduleid}/attendance")
-    public ResponseEntity<AttendanceStatusResponseDto> getIndividualAttendanceStatus(
-        @PathVariable("scheduleid") Long scheduleId,
+    @GetMapping("/schedules/{schedule_id}/me")
+    public ResponseEntity<AttendanceStatusResponseDto> getMyAttendanceStatus(
+        @PathVariable("schedule_id") Long scheduleId,
         @Parameter(hidden = true) @CurrentUser User user
     ) {
-        return ResponseEntity.ok(attendanceService.getIndividualAttendanceStatus(scheduleId, user));
+        return ResponseEntity.ok(attendanceService.getMyAttendanceStatus(scheduleId, user));
+    }
+
+    @Api403ForbiddenStudyMemberOnlyError
+    @Api404StudyNotFoundError
+    @Operation(
+            summary = "특정 스케줄 참여 현황 조회",
+            description = "특정 스케줄의 스터디원 참여 현황을 조회합니다. (스터디 리더만 가능)"
+    )
+    @ApiResponse(
+            responseCode = "200", description = "전체 참여 현황 조회 성공",
+            content = @Content(schema = @Schema(implementation = AttendanceListResponseDto.class))
+    )
+    @Parameters({
+            @Parameter(name = "study_id", description = "참여 현황을 조회할 스터디의 ID", required = true, example = "1")
+    })
+    @GetMapping("/studies/{study_id}/attendances/{schedule_id}")
+    public ResponseEntity<AttendanceListResponseDto> getScheduleAttendance(
+            @PathVariable("study_id") Long studyId,
+            @PathVariable("schedule_id") Long scheuleId,
+            @Parameter(hidden = true) @CurrentUser User user
+    ) {
+        return ResponseEntity.ok(attendanceService.getScheduleAttendance(studyId, scheuleId, user));
     }
 
     @Api403ForbiddenStudyMemberOnlyError
     @Api404ScheduleNotFoundError
     @Operation(
-        summary = "출석 체크",
-        description = "스터디원이 자신의 출석을 체크합니다."
+            summary = "참석 여부 수정",
+            description = "스터디 리더가 스터디원의 참석 여부를 수정합니다."
     )
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "출석 체크 성공",
-            content = @Content(schema = @Schema(implementation = AttendanceStatusResponseDto.class))),
-        @ApiResponse(responseCode = "409", description = "출석 시간 만료 또는 이미 출석 체크됨",
-            content = @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = ErrorResponseDto.class),
-                examples = {
-                    @ExampleObject(
-                        name = "이미 출석 체크됨 예시",
-                        value = """
-                            {
-                              "code": "ALREADY_CHECKED_IN",
-                              "message": "이미 출석 체크되었습니다.",
-                              "errors": [],
-                              "timestamp": "2025-09-07T08:15:10.8668626",
-                              "path": "/api/schedules/1234/attendance"
-                            }
-                            """
-                    )
-                })
-        )
+            @ApiResponse(responseCode = "200", description = "참석 수정 성공",
+                    content = @Content(schema = @Schema(implementation = AttendanceStatusResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.")
     })
     @Parameters({
-        @Parameter(name = "schedule_id", description = "출석 체크할 일정의 ID", required = true, example = "1234")
+            @Parameter(name = "schedule_id", description = "참석 여부 수정할 일정의 ID", required = true, example = "1234")
     })
-    @PostMapping("/schedules/{schedule_id}/attendance")
-    public ResponseEntity<AttendanceStatusResponseDto> checkAttendance(
+    @PatchMapping("/schedules/{schedule_id}/attendances")
+    public ResponseEntity<AttendanceStatusResponseDto> changeAttendance(
+            @PathVariable("schedule_id") Long scheduleId,
+            @RequestBody AttendanceMemberStatusRequestDto attendanceMemberStatusRequestDto,
+            @Parameter(hidden = true) @CurrentUser User user
+    ) {
+        attendanceService.changeMemberAttendanceStatus(scheduleId, attendanceMemberStatusRequestDto, user);
+        return ResponseEntity.status(HttpsURLConnection.HTTP_OK).build();
+    }
+
+    @Api403ForbiddenStudyMemberOnlyError
+    @Api404ScheduleNotFoundError
+    @Operation(
+        summary = "참석 여부 추가",
+        description = "스터디원이 자신의 참석 여부를 추가합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "참석 추가 성공",
+            content = @Content(schema = @Schema(implementation = AttendanceStatusResponseDto.class)))
+    })
+    @Parameters({
+        @Parameter(name = "schedule_id", description = "참석 여부 추가할 일정의 ID", required = true, example = "1234")
+    })
+    @PatchMapping("/schedules/{schedule_id}/attendances/me")
+    public ResponseEntity<Void> addAttendance(
         @PathVariable("schedule_id") Long scheduleId,
+        @RequestBody AttendanceStatusRequestDto  attendanceStatusRequestDto,
         @Parameter(hidden = true) @CurrentUser User user
     ) {
-        return ResponseEntity.ok(attendanceService.checkIn(scheduleId, user));
+        attendanceService.changeMyAttendanceStatus(scheduleId, attendanceStatusRequestDto, user);
+        return ResponseEntity.status(HttpsURLConnection.HTTP_OK).build();
     }
 }

--- a/src/main/java/com/pado/domain/attendance/dto/AttendanceMemberStatusRequestDto.java
+++ b/src/main/java/com/pado/domain/attendance/dto/AttendanceMemberStatusRequestDto.java
@@ -1,0 +1,12 @@
+package com.pado.domain.attendance.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "특정 스터디원 참여 여부 요청 DTO")
+public record AttendanceMemberStatusRequestDto (
+        @Schema(description = "스터디원 닉네임")
+        String nickname,
+        @Schema(description = "참석 여부")
+        boolean status
+){
+}

--- a/src/main/java/com/pado/domain/attendance/dto/AttendanceStatusRequestDto.java
+++ b/src/main/java/com/pado/domain/attendance/dto/AttendanceStatusRequestDto.java
@@ -1,0 +1,9 @@
+package com.pado.domain.attendance.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AttendanceStatusRequestDto(
+        @Schema(description = "참석 여부")
+        boolean status
+) {
+}

--- a/src/main/java/com/pado/domain/attendance/entity/Attendance.java
+++ b/src/main/java/com/pado/domain/attendance/entity/Attendance.java
@@ -37,13 +37,17 @@ public class Attendance {
     @Column(name = "check_in_time")
     private LocalDateTime checkInTime;
 
-    public static Attendance createCheckIn(Schedule schedule, User user) {
+    public static Attendance createCheckIn(Schedule schedule, boolean status, User user) {
         return Attendance.builder()
                 .schedule(schedule)
                 .user(user)
-                .status(true)
+                .status(status)
                 .checkInTime(LocalDateTime.now())
                 .build();
+    }
+
+    public void changestatus(boolean status){
+        this.status = status;
     }
 }
 

--- a/src/main/java/com/pado/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/com/pado/domain/attendance/repository/AttendanceRepository.java
@@ -10,12 +10,15 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 
 @Repository
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     boolean existsByScheduleAndUser(Schedule schedule, User user);
+
+    Optional<Attendance> findByScheduleAndUser(Schedule schedule, User user);
 
     @Query("""
         select a
@@ -25,6 +28,15 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
         where s.studyId = :studyId
     """)
     List<Attendance> findAllByStudyIdWithScheduleAndUser(@Param("studyId") Long studyId);
+
+    @Query("""
+        select a
+        from Attendance a
+        join fetch a.schedule
+        join fetch a.user
+        where a.schedule = :schedule
+    """)
+    List<Attendance> findAllByScheduleWithScheduleAndUser (@Param("schedule") Schedule schedule);
 
     int countByScheduleId(Long scheduleId);
 

--- a/src/main/java/com/pado/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/pado/domain/attendance/service/AttendanceService.java
@@ -2,6 +2,8 @@ package com.pado.domain.attendance.service;
 
 
 import com.pado.domain.attendance.dto.AttendanceListResponseDto;
+import com.pado.domain.attendance.dto.AttendanceMemberStatusRequestDto;
+import com.pado.domain.attendance.dto.AttendanceStatusRequestDto;
 import com.pado.domain.attendance.dto.AttendanceStatusResponseDto;
 import com.pado.domain.user.entity.User;
 
@@ -11,8 +13,16 @@ public interface AttendanceService {
     AttendanceListResponseDto getFullAttendance(Long studyId);
 
     // 개별 참여 현황 조회
-    AttendanceStatusResponseDto getIndividualAttendanceStatus(Long scheduleId, User user);
+    AttendanceStatusResponseDto getMyAttendanceStatus(Long scheduleId, User user);
 
-    // 출석
-    AttendanceStatusResponseDto checkIn(Long ScheduleId, User user);
+    //특정 스케줄 맴버 참가 현황 조회
+    AttendanceListResponseDto getScheduleAttendance(Long studyId, Long scheduleId, User user);
+
+    //리더가 맴버 참가여부 수정
+    void changeMemberAttendanceStatus(Long scheduleId, AttendanceMemberStatusRequestDto attendanceMemberStatusRequestDto, User user);
+
+    // 본인 참가여부 표시
+    void changeMyAttendanceStatus(Long ScheduleId, AttendanceStatusRequestDto attendanceStatusRequestDto, User user);
+
+
 }

--- a/src/main/java/com/pado/domain/attendance/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/pado/domain/attendance/service/AttendanceServiceImpl.java
@@ -1,9 +1,6 @@
 package com.pado.domain.attendance.service;
 
-import com.pado.domain.attendance.dto.AttendanceListResponseDto;
-import com.pado.domain.attendance.dto.AttendanceStatusDto;
-import com.pado.domain.attendance.dto.AttendanceStatusResponseDto;
-import com.pado.domain.attendance.dto.MemberAttendanceDto;
+import com.pado.domain.attendance.dto.*;
 import com.pado.domain.attendance.entity.Attendance;
 import com.pado.domain.attendance.repository.AttendanceRepository;
 import com.pado.domain.schedule.entity.Schedule;
@@ -14,14 +11,14 @@ import com.pado.domain.study.entity.StudyMemberRole;
 import com.pado.domain.study.repository.StudyMemberRepository;
 import com.pado.domain.study.repository.StudyRepository;
 import com.pado.domain.user.entity.User;
+import com.pado.domain.user.repository.UserRepository;
 import com.pado.global.exception.common.BusinessException;
 import com.pado.global.exception.common.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -32,6 +29,7 @@ public class AttendanceServiceImpl implements AttendanceService {
     private final ScheduleRepository scheduleRepository;
     private final StudyMemberRepository studyMemberRepository;
     private final StudyRepository studyRepository;
+    private final UserRepository userRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -84,30 +82,81 @@ public class AttendanceServiceImpl implements AttendanceService {
 
 
     @Override
-    public AttendanceStatusResponseDto getIndividualAttendanceStatus(Long scheduleId, User user) {
-        Schedule schedule = checkException(scheduleId, user);
-        return new AttendanceStatusResponseDto(
-            attendanceRepository.existsByScheduleAndUser(schedule, user));
-    }
+    public AttendanceStatusResponseDto getMyAttendanceStatus(Long scheduleId, User user) {
+        Schedule schedule = checkException(scheduleId, user, StudyMemberRole.MEMBER);
+        Optional<Attendance> existingAttendance = attendanceRepository.findByScheduleAndUser(schedule, user);
 
+        if (existingAttendance.isPresent()) {
+            Attendance attendance = existingAttendance.get();
+            return new AttendanceStatusResponseDto(attendance.isStatus());
+        }
+        else {
+            return new AttendanceStatusResponseDto(false);
+        }
+    }
 
     @Override
-    public AttendanceStatusResponseDto checkIn(Long scheduleId, User user) {
-        Schedule schedule = checkException(scheduleId, user);
+    @Transactional
+    public AttendanceListResponseDto getScheduleAttendance(Long studyId, Long scheduleId, User user) {
+        Schedule schedule = checkException(scheduleId, user, StudyMemberRole.LEADER);
+        List<Attendance> attendances = attendanceRepository.findAllByScheduleWithScheduleAndUser(schedule);
+        Study study = studyRepository.findById(studyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
+        Long leaderId = studyMemberRepository.findLeaderUserIdByStudy(study, StudyMemberRole.LEADER);
+        List<StudyMember> studyMembers = studyMemberRepository.findByStudyWithUser(study);
+        List<StudyMember> orderedMembers = studyMembers.stream()
+                .sorted(Comparator.comparing(sm -> !sm.getUser().getId().equals(leaderId)))
+                .toList();
 
-        // 출석 여부 확인
-        if (attendanceRepository.existsByScheduleAndUser(schedule, user)) {
-            throw new BusinessException(ErrorCode.ALREADY_CHECKED_IN);
-        }
+        Map<Long, Attendance> attendanceByUser = attendances.stream()
+                .collect(Collectors.toMap(a -> a.getUser().getId(), a->a));
 
-        Attendance attendance = Attendance.createCheckIn(schedule, user);
-        attendanceRepository.save(attendance);
+        List<MemberAttendanceDto> memberAttendanceDtoList = orderedMembers.stream()
+                .map(studyMember -> {
+                    User targetuser = studyMember.getUser();
+                    Attendance attendance = attendanceByUser.get(targetuser.getId());
+                    boolean status = attendance != null && attendance.isStatus();
+                    AttendanceStatusDto attendanceStatusDto = new AttendanceStatusDto(status, schedule.getStartTime());
+                    return new MemberAttendanceDto(targetuser.getNickname(), targetuser.getImage_key(), List.of(attendanceStatusDto));
+                })
+                .toList();
 
-        return new AttendanceStatusResponseDto(true);
+        return new AttendanceListResponseDto(memberAttendanceDtoList);
     }
 
+    @Override
+    @Transactional
+    public void changeMemberAttendanceStatus(Long scheduleId, AttendanceMemberStatusRequestDto dto, User user) {
+        Schedule schedule = checkException(scheduleId, user, StudyMemberRole.LEADER);
+        User targetUser = userRepository.findByNickname(dto.nickname()).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        updateAttendanceStatus(schedule, dto.status(), targetUser);
+    }
+
+    @Override
+    @Transactional
+    public void changeMyAttendanceStatus(Long scheduleId, AttendanceStatusRequestDto dto, User user) {
+        Schedule schedule = checkException(scheduleId, user, StudyMemberRole.MEMBER);
+        updateAttendanceStatus(schedule, dto.status(), user);
+
+    }
+
+    // 공통 참석 여부 변경 코드
+    private void updateAttendanceStatus(Schedule schedule, boolean status, User user) {
+        Optional<Attendance> existingAttendance = attendanceRepository.findByScheduleAndUser(schedule, user);
+
+        if (existingAttendance.isPresent()) {
+            Attendance attendance = existingAttendance.get();
+            attendance.changestatus(status);
+        }
+        else {
+            Attendance attendance = Attendance.createCheckIn(schedule, status, user);
+            attendanceRepository.save(attendance);
+        }
+    }
+
+
     // 공통 예외 검증
-    private Schedule checkException(Long scheduleId, User user) {
+    private Schedule checkException(Long scheduleId, User user, StudyMemberRole required) {
         // 스케줄 검증
         Schedule schedule = scheduleRepository.findById(scheduleId)
             .orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND));
@@ -117,8 +166,12 @@ public class AttendanceServiceImpl implements AttendanceService {
             .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
 
         // 스터디 멤버 검증
-        if (!studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))) {
-            throw new BusinessException(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY);
+        Collection<StudyMemberRole> allowed =
+                (required == StudyMemberRole.LEADER) ? List.of(StudyMemberRole.LEADER) : List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER);
+        if (!studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), allowed)) {
+            throw new BusinessException(
+                    (required == StudyMemberRole.LEADER) ? ErrorCode.FORBIDDEN_STUDY_LEADER_ONLY
+                            : ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY);
         }
 
         return schedule;

--- a/src/main/java/com/pado/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/pado/domain/auth/service/AuthServiceImpl.java
@@ -65,9 +65,9 @@ public class AuthServiceImpl implements AuthService{
     public TokenWithRefreshResponseDto login(LoginRequestDto request) {
         User user = userRepository.findByEmail(request.email())
             .orElseThrow(
-                () -> new BusinessException(ErrorCode.UNAUTHENTICATED_USER, "Invalid credentials"));
+                () -> new BusinessException(ErrorCode.UNAUTHENTICATED_USER));
         if (!passwordEncoder.matches(request.password(), user.getPasswordHash())) {
-            throw new BusinessException(ErrorCode.UNAUTHENTICATED_USER, "Invalid credentials");
+            throw new BusinessException(ErrorCode.UNAUTHENTICATED_USER);
         }
 
         String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());

--- a/src/main/java/com/pado/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/pado/domain/user/repository/UserRepository.java
@@ -12,4 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     @EntityGraph(attributePaths = "interests")
     Optional<User> findWithInterestsById(Long id);
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/pado/global/exception/common/ErrorCode.java
+++ b/src/main/java/com/pado/global/exception/common/ErrorCode.java
@@ -57,7 +57,6 @@ public enum ErrorCode {
     PENDING_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "PENDING_SCHEDULE_NOT_FOUND",
         "승인 대기 중인 일정을 찾을 수 없습니다."),
     INVALID_STATE_CHANGE(HttpStatus.CONFLICT, "INVALID_STATE_CHANGE", "상태 변경이 유효하지 않습니다."),
-    ALREADY_CHECKED_IN(HttpStatus.CONFLICT, "ALREADY_CHECKED_IN", "이미 출석 체크되었습니다."),
     ALREADY_MEMBER(HttpStatus.CONFLICT, "ALREADY_MEMBER", "이미 스터디의 멤버입니다."),
     ALREADY_APPLIED(HttpStatus.CONFLICT, "ALREADY_APPLIED", "이미 스터디에 참여 신청했습니다."),
     STUDY_NOT_RECRUITING(HttpStatus.BAD_REQUEST, "STUDY_NOT_RECRUITING", "모집 중인 스터디가 아닙니다."),

--- a/src/test/java/com/pado/domain/attendance/service/AttendanceServiceImplTest.java
+++ b/src/test/java/com/pado/domain/attendance/service/AttendanceServiceImplTest.java
@@ -1,12 +1,7 @@
 package com.pado.domain.attendance.service;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.ArgumentMatchers.any;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.then;
-
 import com.pado.domain.attendance.dto.AttendanceListResponseDto;
+import com.pado.domain.attendance.dto.AttendanceStatusRequestDto;
 import com.pado.domain.attendance.dto.AttendanceStatusResponseDto;
 import com.pado.domain.attendance.dto.MemberAttendanceDto;
 import com.pado.domain.attendance.entity.Attendance;
@@ -21,22 +16,29 @@ import com.pado.domain.study.repository.StudyMemberRepository;
 import com.pado.domain.study.repository.StudyRepository;
 import com.pado.domain.user.entity.Gender;
 import com.pado.domain.user.entity.User;
+import com.pado.domain.user.repository.UserRepository;
 import com.pado.global.exception.common.BusinessException;
 import com.pado.global.exception.common.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class AttendanceServiceImplTest {
@@ -52,6 +54,8 @@ class AttendanceServiceImplTest {
     private StudyRepository studyRepository;
     @Mock
     private StudyMemberRepository studyMemberRepository;
+    @Mock
+    private UserRepository userRepository;
 
     private User testUser(Long id) {
         User u = User.builder()
@@ -132,7 +136,7 @@ class AttendanceServiceImplTest {
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
+        assertThatThrownBy(() -> attendanceService.changeMyAttendanceStatus(scheduleId, new AttendanceStatusRequestDto(true),user))
             .isInstanceOf(BusinessException.class)
             .hasMessageContaining(ErrorCode.SCHEDULE_NOT_FOUND.message);
     }
@@ -151,127 +155,14 @@ class AttendanceServiceImplTest {
         given(studyRepository.findById(studyId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
+        assertThatThrownBy(() -> attendanceService.changeMyAttendanceStatus(scheduleId, new AttendanceStatusRequestDto(true), user))
             .isInstanceOf(BusinessException.class)
             .hasMessageContaining(ErrorCode.STUDY_NOT_FOUND.message);
     }
 
     @Test
-    @DisplayName("스터디 멤버가 아니면 예외 발생")
-    void 스터디_멤버_아닐_때_예외() {
-        // given
-        Long userId = 10L;
-        Long scheduleId = 1L;
-        Long studyId = 100L;
-        User user = testUser(userId);
-        Schedule schedule = testSchedule(studyId);
-        Study study = testStudy(studyId);
-
-        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
-        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
-        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(false);
-
-        // when & then
-        assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
-            .isInstanceOf(BusinessException.class)
-            .hasMessageContaining(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY.message);
-    }
-
-    @Test
-    @DisplayName("이미 출석한 경우 예외 발생")
-    void 이미_출석했을_때_예외() {
-        // given
-        Long userId = 10L;
-        Long scheduleId = 1L;
-        Long studyId = 100L;
-        User user = testUser(userId);
-        Schedule schedule = testSchedule(studyId);
-        Study study = testStudy(studyId);
-
-        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
-        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
-        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(true);
-        given(attendanceRepository.existsByScheduleAndUser(schedule, user)).willReturn(true);
-
-        // when & then
-        assertThatThrownBy(() -> attendanceService.checkIn(scheduleId, user))
-            .isInstanceOf(BusinessException.class)
-            .hasMessageContaining(ErrorCode.ALREADY_CHECKED_IN.message);
-    }
-
-    @Test
-    @DisplayName("출석 성공")
-    void 출석_성공_여부() {
-        Long userId = 10L;
-        Long scheduleId = 1L;
-        Long studyId = 100L;
-        User user = testUser(userId);
-        Schedule schedule = testSchedule(studyId);
-        Study study = testStudy(studyId);
-
-        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
-        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
-        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(true);
-        given(attendanceRepository.existsByScheduleAndUser(schedule, user)).willReturn(false);
-
-        // when
-        AttendanceStatusResponseDto response = attendanceService.checkIn(scheduleId, user);
-
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.status()).isTrue();
-        then(attendanceRepository).should(times(1)).save(any(Attendance.class));
-    }
-
-    @Test
-    @DisplayName("출석한 경우 개별 출석 여부 확인")
-    void 개별_출석_확인_출석() {
-        // given
-        Long userId = 10L;
-        Long scheduleId = 1L;
-        Long studyId = 100L;
-        User user = testUser(userId);
-        Schedule schedule = testSchedule(studyId);
-        Study study = testStudy(studyId);
-
-        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
-        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
-        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(true);
-        given(attendanceRepository.existsByScheduleAndUser(schedule, user)).willReturn(true);
-
-        AttendanceStatusResponseDto response = attendanceService.getIndividualAttendanceStatus(
-            scheduleId, user);
-        assertThat(response).isNotNull();
-        assertThat(response.status()).isTrue();
-        then(attendanceRepository).should(times(0)).save(any(Attendance.class));
-    }
-
-    @Test
-    @DisplayName("미출석한 경우 개별 출석 여부 확인")
-    void 개별_출석_확인_미출석() {
-        // given
-        Long userId = 10L;
-        Long scheduleId = 1L;
-        Long studyId = 100L;
-        User user = testUser(userId);
-        Schedule schedule = testSchedule(studyId);
-        Study study = testStudy(studyId);
-
-        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
-        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
-        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(true);
-        given(attendanceRepository.existsByScheduleAndUser(schedule, user)).willReturn(false);
-
-        AttendanceStatusResponseDto response = attendanceService.getIndividualAttendanceStatus(
-            scheduleId, user);
-        assertThat(response).isNotNull();
-        assertThat(response.status()).isFalse();
-        then(attendanceRepository).should(times(0)).save(any(Attendance.class));
-    }
-
-    @Test
-    @DisplayName("모든 스케줄 기준으로 멤버별 출석 여부를 확인")
-    void 모든_출석_확인() {
+    @DisplayName("모든 스케줄 기준으로 멤버별 참가 여부를 확인")
+    void 모든_참가_확인() {
         // given
         Long studyId = 100L;
         Study study = testStudy(studyId);
@@ -296,9 +187,9 @@ class AttendanceServiceImplTest {
         given(studyMemberRepository.findByStudyWithUser(study)).willReturn(members);
         given(scheduleRepository.findByStudyIdOrderByStartTimeAsc(studyId)).willReturn(schedules);
         given(attendanceRepository.findAllByStudyIdWithScheduleAndUser(studyId)).willReturn(
-            attendanceList);
+                attendanceList);
         given(studyMemberRepository.findLeaderUserIdByStudy(study,
-            StudyMemberRole.LEADER)).willReturn(u2.getId());
+                StudyMemberRole.LEADER)).willReturn(u2.getId());
 
         // when
         AttendanceListResponseDto resp = attendanceService.getFullAttendance(studyId);
@@ -329,4 +220,276 @@ class AttendanceServiceImplTest {
         then(scheduleRepository).should(times(1)).findByStudyIdOrderByStartTimeAsc(studyId);
         then(attendanceRepository).should(times(1)).findAllByStudyIdWithScheduleAndUser(studyId);
     }
+
+    @Test
+    @DisplayName("전체 출석 요약: 스케줄이 없으면 각 멤버 attendance 리스트는 빈 배열")
+    void 전체출석_스케줄없음_빈리스트() {
+        Long studyId = 100L;
+        Study study = testStudy(studyId);
+        User leader = testUser(1L, "leader");
+        User m1 = testUser(2L, "m1");
+
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.findByStudyWithUser(study))
+                .willReturn(List.of(testStudyMember(study, leader, StudyMemberRole.LEADER),
+                        testStudyMember(study, m1, StudyMemberRole.MEMBER)));
+        given(scheduleRepository.findByStudyIdOrderByStartTimeAsc(studyId)).willReturn(List.of());
+        given(attendanceRepository.findAllByStudyIdWithScheduleAndUser(studyId)).willReturn(List.of());
+        given(studyMemberRepository.findLeaderUserIdByStudy(study, StudyMemberRole.LEADER))
+                .willReturn(leader.getId());
+
+        AttendanceListResponseDto resp = attendanceService.getFullAttendance(studyId);
+        assertThat(resp.members()).hasSize(2);
+        assertThat(resp.members().get(0).attendance()).isEmpty();
+        assertThat(resp.members().get(1).attendance()).isEmpty();
+    }
+
+
+    @Test
+    @DisplayName("참가한 경우 개별 참가 여부 확인")
+    void 개별_참가_확인_출석() {
+        // given
+        Long userId = 10L;
+        Long scheduleId = 1L;
+        Long studyId = 100L;
+        User user = testUser(userId);
+        Schedule schedule = testSchedule(studyId);
+        Study study = testStudy(studyId);
+        Attendance existing = Attendance.builder()
+                .schedule(schedule).user(user).status(true).build();
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(true);
+        given(attendanceRepository.findByScheduleAndUser(schedule, user)).willReturn(Optional.of(existing));
+
+        AttendanceStatusResponseDto response = attendanceService.getMyAttendanceStatus(
+                scheduleId, user);
+        assertThat(response).isNotNull();
+        assertThat(response.status()).isTrue();
+        then(attendanceRepository).should(times(0)).save(any(Attendance.class));
+    }
+
+    @Test
+    @DisplayName("미참가한 경우 개별 참가 여부 확인")
+    void 개별_참가_확인_미출석() {
+        // given
+        Long userId = 10L;
+        Long scheduleId = 1L;
+        Long studyId = 100L;
+        User user = testUser(userId);
+        Schedule schedule = testSchedule(studyId);
+        Study study = testStudy(studyId);
+        Attendance existing = Attendance.builder()
+                .schedule(schedule).user(user).status(false).build();
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(true);
+        given(attendanceRepository.findByScheduleAndUser(schedule, user)).willReturn(Optional.of(existing));
+
+        AttendanceStatusResponseDto response = attendanceService.getMyAttendanceStatus(
+                scheduleId, user);
+        assertThat(response).isNotNull();
+        assertThat(response.status()).isFalse();
+        then(attendanceRepository).should(times(0)).save(any(Attendance.class));
+    }
+
+    @Test
+    @DisplayName("미참가한 경우 개별 참가 여부 확인(엔티티 없을 경우)")
+    void 개별_참가_확인_엔티티_없을_경우() {
+        Long userId = 10L; Long scheduleId = 1L; Long studyId = 100L;
+        User user = testUser(userId);
+        Schedule schedule = testSchedule(studyId);
+        Study study = testStudy(studyId);
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(
+                studyId, userId, List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))
+        ).willReturn(true);
+        given(attendanceRepository.findByScheduleAndUser(schedule, user)).willReturn(Optional.empty());
+
+        AttendanceStatusResponseDto resp = attendanceService.getMyAttendanceStatus(scheduleId, user);
+        assertThat(resp.status()).isFalse();
+    }
+
+    @Test
+    @DisplayName("특정 스케줄 전체 참여 현황: 리더가 아니면 예외")
+    void 특정스케줄_전체현황_리더아님_예외() {
+        Long studyId = 100L; Long scheduleId = 1L;
+        User actor = testUser(10L, "user");
+        Study study = testStudy(studyId);
+        Schedule schedule = testSchedule(scheduleId, studyId, LocalDateTime.now());
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(
+                studyId, actor.getId(), List.of(StudyMemberRole.LEADER))
+        ).willReturn(false); // 리더 아님
+
+        assertThatThrownBy(() -> attendanceService.getScheduleAttendance(studyId, scheduleId, actor))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.FORBIDDEN_STUDY_LEADER_ONLY.message);
+    }
+
+    @Test
+    @DisplayName("리더가 멤버 출석 변경: 기존 레코드 있으면 상태만 변경, save() 없음")
+    void 리더_멤버출석_업데이트() {
+        Long scheduleId = 1L; Long studyId = 100L;
+        User leader = testUser(1L, "leader");
+        User target = testUser(2L, "target");
+        Study study = testStudy(studyId);
+        Schedule schedule = testSchedule(scheduleId, studyId, LocalDateTime.now());
+
+        Attendance existing = testAttendance(99L, schedule, target, false);
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(
+                studyId, leader.getId(), List.of(StudyMemberRole.LEADER))
+        ).willReturn(true);
+        given(userRepository.findByNickname("target")).willReturn(Optional.of(target));
+        given(attendanceRepository.findByScheduleAndUser(schedule, target)).willReturn(Optional.of(existing));
+
+        attendanceService.changeMemberAttendanceStatus(scheduleId,
+                new com.pado.domain.attendance.dto.AttendanceMemberStatusRequestDto("target", true),
+                leader);
+
+        assertThat(existing.isStatus()).isTrue();
+        then(attendanceRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("리더가 멤버 출석 변경: 레코드 없으면 생성, save() 1회")
+    void 리더_멤버출석_생성() {
+        Long scheduleId = 1L; Long studyId = 100L;
+        User leader = testUser(1L, "leader");
+        User target = testUser(2L, "target");
+        Study study = testStudy(studyId);
+        Schedule schedule = testSchedule(scheduleId, studyId, LocalDateTime.now());
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(
+                studyId, leader.getId(), List.of(StudyMemberRole.LEADER))
+        ).willReturn(true);
+        given(userRepository.findByNickname("target")).willReturn(Optional.of(target));
+        given(attendanceRepository.findByScheduleAndUser(schedule, target)).willReturn(Optional.empty());
+
+        attendanceService.changeMemberAttendanceStatus(scheduleId,
+                new com.pado.domain.attendance.dto.AttendanceMemberStatusRequestDto("target", true),
+                leader);
+
+        ArgumentCaptor<Attendance> captor = ArgumentCaptor.forClass(Attendance.class);
+        then(attendanceRepository).should(times(1)).save(captor.capture());
+        Attendance saved = captor.getValue();
+        assertThat(saved.getUser()).isEqualTo(target);
+        assertThat(saved.getSchedule()).isEqualTo(schedule);
+        assertThat(saved.isStatus()).isTrue();
+    }
+
+    @Test
+    @DisplayName("리더가 아닌 사용자가 멤버 출석 변경 시도 → 예외")
+    void 리더아님_멤버출석_예외() {
+        Long scheduleId = 1L; Long studyId = 100L;
+        User actor = testUser(10L, "notLeader");
+        Study study = testStudy(studyId);
+        Schedule schedule = testSchedule(scheduleId, studyId, LocalDateTime.now());
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(
+                studyId, actor.getId(), List.of(StudyMemberRole.LEADER))
+        ).willReturn(false);
+
+        assertThatThrownBy(() ->
+                attendanceService.changeMemberAttendanceStatus(scheduleId,
+                        new com.pado.domain.attendance.dto.AttendanceMemberStatusRequestDto("who", true),
+                        actor)
+        ).isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.FORBIDDEN_STUDY_LEADER_ONLY.message);
+    }
+
+    @Test
+    @DisplayName("스터디 멤버가 아니면 예외 발생")
+    void 스터디_멤버_아닐_때_예외() {
+        // given
+        Long userId = 10L;
+        Long scheduleId = 1L;
+        Long studyId = 100L;
+        User user = testUser(userId);
+        Schedule schedule = testSchedule(studyId);
+        Study study = testStudy(studyId);
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(study.getId(), user.getId(), List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> attendanceService.changeMyAttendanceStatus(scheduleId, new AttendanceStatusRequestDto(true), user))
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY.message);
+    }
+
+
+    @Test
+    @DisplayName("참가 상태로 변경")
+    void 참가_변경() {
+        Long scheduleId = 1L; Long studyId = 100L; Long userId = 10L;
+        User user = testUser(userId);
+        Schedule schedule = testSchedule(studyId);
+        Study study = testStudy(studyId);
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(
+                studyId, userId, List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))
+        ).willReturn(true);
+        // 핵심: findBy... 는 empty
+        given(attendanceRepository.findByScheduleAndUser(schedule, user)).willReturn(Optional.empty());
+
+        // when
+        attendanceService.changeMyAttendanceStatus(scheduleId, new AttendanceStatusRequestDto(true), user);
+
+        // then
+        ArgumentCaptor<Attendance> captor = ArgumentCaptor.forClass(Attendance.class);
+        then(attendanceRepository).should(times(1)).save(captor.capture());
+        Attendance saved = captor.getValue();
+        assertThat(saved.isStatus()).isTrue();  // createCheckIn 내부에서 true 세팅되는지 검증
+        assertThat(saved.getSchedule()).isEqualTo(schedule);
+        assertThat(saved.getUser()).isEqualTo(user);
+
+        // 존재 경로에선 save가 0이어야
+        then(attendanceRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("미참가 상태로 변경")
+    void 미참가_변경() {
+        Long scheduleId = 1L; Long studyId = 100L; Long userId = 10L;
+        User user = testUser(userId);
+        Schedule schedule = testSchedule(studyId);
+        Study study = testStudy(studyId);
+
+        Attendance existing = Attendance.builder()
+                .schedule(schedule).user(user).status(true).build();
+
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(studyRepository.findById(studyId)).willReturn(Optional.of(study));
+        given(studyMemberRepository.existsByStudyIdAndUserIdAndRoleIn(
+                studyId, userId, List.of(StudyMemberRole.LEADER, StudyMemberRole.MEMBER))
+        ).willReturn(true);
+        given(attendanceRepository.findByScheduleAndUser(schedule, user)).willReturn(Optional.of(existing));
+
+        // when
+        attendanceService.changeMyAttendanceStatus(scheduleId, new AttendanceStatusRequestDto(false), user);
+
+        // then
+        assertThat(existing.isStatus()).isFalse();  // changeStatus(false) 적용됐는지
+        then(attendanceRepository).should(never()).save(any()); // 더티체킹만
+    }
+
+
+
 }


### PR DESCRIPTION
## ✨ 요약

특정 스케줄의 참여(출석) 여부 조회·수정·추가 기능을 서비스/레포지토리/DTO/테스트까지 일괄 구현했습니다.

## 🔗 작업 내용

-feat(attendance): 참여 여부 조회/수정/추가 Request/Response DTO 추가
-fix(attendance): 서비스 로직으로 참여 여부 조회/수정/추가 구현
-feat(repository): 위 서비스 로직에 필요한 조회 메서드 및 페치 전략 보완
-fix(error): 불필요한 중복 출석 에러코드 제거
-test: 특정 스케줄 멤버 참가 조회/수정/추가에 대한 단위 테스트 추가

## 💻 상세 구현 내용

getMyAttendanceStatus(scheduleId, user): 개인의 해당 스케줄 참여 여부 단건 조회
getScheduleAttendance(studyId, scheduleId, actor): 특정 스케줄의 전체 멤버 참여 현황 조회(리더 전용)
멤버별 Attendance가 없으면 false로 채워 NPE 방지
changeMyAttendanceStatus(scheduleId, dto, user): 본인 참여 여부 설정
changeMemberAttendanceStatus(scheduleId, dto, actor): 리더가 특정 멤버 참여 여부 설정
공통 내부 메서드 updateAttendanceStatus(schedule, status, targetUser): 존재 시 changeStatus(status), 미존재 시 Attendance.createCheckIn(...) → save로 신규 생성

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #107

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)