### PR TITLE
Feat: 읽지 않은 메세지 수와 읽지 않은 멤버 수를 보여주는 기능 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,12 +164,23 @@ jobs:
             NAME="pado-pr-${{ github.run_id }}"
             
             echo "Pull $IMAGE and run on localhost:${PORT} ..."
+
+            # FIX 1: 포트 충돌 방지를 위해 기존 컨테이너를 먼저 삭제
+            OLD_CONTAINER_ID=$(sudo docker ps -q --filter "publish=${PORT}")
+            if [ -n "$OLD_CONTAINER_ID" ]; then
+              echo "Found and stopping stale container using port ${PORT}: ${OLD_CONTAINER_ID}"
+              sudo docker rm -f "$OLD_CONTAINER_ID"
+            fi
+            
             sudo docker pull "$IMAGE"
             sudo docker rm -f "$NAME" 2>/dev/null || true
             sudo docker network inspect pado-net >/dev/null 2>&1 || sudo docker network create pado-net
-            sudo docker network connect pado-net redis || true
             
-            # Create PR env file on remote (prevent expansion with quoted heredoc)
+            # FIX 2: redis 컨테이너를 직접 조회하는 안정적인 방식으로 네트워크 연결을 확인
+            if ! sudo docker inspect redis -f '{{json .NetworkSettings.Networks}}' | grep -q "pado-net"; then
+              sudo docker network connect pado-net redis
+            fi
+            
             cat > /tmp/pado-pr.env <<'EOF'
             SPRING_PROFILES_ACTIVE=prod
             DB_USERNAME=${{ secrets.DB_USERNAME }}
@@ -208,17 +219,20 @@ jobs:
               sleep 5
             done
             
+            # FIX 3: 실패 시 상세한 디버깅 로그를 출력하도록 개선
             if [ "${OK:-false}" != true ]; then
-              echo "--- Health response ---"
-              curl -s "$HEALTH" || true
+              echo "--- Health check failed. Displaying debug information. ---"
+              echo "--- Health endpoint response: ---"
+              curl -v "$HEALTH" || echo "curl command failed"
               echo
-              echo "--- Logs ---"
-              sudo docker logs "$NAME" || true
+              echo "--- Application container logs: ---"
+              sudo docker logs "$NAME"
               sudo docker rm -f "$NAME" || true
               sudo shred -u /tmp/pado-pr.env || sudo rm -f /tmp/pado-pr.env || true
               exit 1
             fi
             
+            # 성공 시 정리
             sudo docker rm -f "$NAME" || true
             sudo shred -u /tmp/pado-pr.env || sudo rm -f /tmp/pado-pr.env || true
             echo "PR EC2 smoke passed."
@@ -295,7 +309,10 @@ jobs:
               sudo docker rm -f "$NEW_NAME"
             fi
             sudo docker network inspect pado-net >/dev/null 2>&1 || sudo docker network create pado-net
-            sudo docker network connect pado-net redis || true
+            
+            if ! sudo docker inspect redis -f '{{json .NetworkSettings.Networks}}' | grep -q "pado-net"; then
+              sudo docker network connect pado-net redis
+            fi
 
             cat > /tmp/pado.env <<'EOF'
             SPRING_PROFILES_ACTIVE=prod
@@ -351,11 +368,12 @@ jobs:
               sudo docker image prune -f
               echo "Deployment complete."
             else
-              echo "--- Health endpoint response ---"
-              curl -s "$HEALTH_CHECK_URL" || true
+              echo "--- Health check failed. Displaying debug information. ---"
+              echo "--- Health endpoint response: ---"
+              curl -v "$HEALTH_CHECK_URL" || echo "curl command failed"
               echo
-              echo "--- Container logs ($NEW_NAME) ---"
-              sudo docker logs "$NEW_NAME" || true
+              echo "--- Container logs ($NEW_NAME): ---"
+              sudo docker logs "$NEW_NAME"
               sudo docker rm -f "$NEW_NAME" || true
               sudo shred -u /tmp/pado.env || sudo rm -f /tmp/pado.env || true
               exit 1

--- a/src/main/java/com/pado/domain/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/com/pado/domain/chat/controller/ChatWebSocketController.java
@@ -1,20 +1,15 @@
 package com.pado.domain.chat.controller;
 
 import com.pado.domain.chat.dto.request.ChatMessageRequestDto;
-import com.pado.domain.chat.dto.response.ChatMessageResponseDto;
 import com.pado.domain.chat.service.ChatService;
 import com.pado.domain.user.entity.User;
 import com.pado.global.auth.annotation.CurrentUser;
-import com.pado.global.exception.common.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
-
-import java.util.Map;
 
 @Slf4j
 @Controller
@@ -22,7 +17,6 @@ import java.util.Map;
 public class ChatWebSocketController {
 
     private final ChatService chatService;
-    private final SimpMessagingTemplate messagingTemplate;
 
     @MessageMapping("/studies/{studyId}/chats")
     public void sendMessage(
@@ -30,7 +24,30 @@ public class ChatWebSocketController {
             @Valid ChatMessageRequestDto requestDto,
             @CurrentUser User currentUser) {
 
-        ChatMessageResponseDto responseDto = chatService.sendMessage(studyId, requestDto, currentUser);
-        messagingTemplate.convertAndSend( "/topic/studies/" + studyId + "/chats", responseDto);
+        chatService.sendMessage(studyId, requestDto, currentUser);
+    }
+
+    @MessageMapping("/studies/{studyId}/modal/open")
+    public void openChatModal(
+            @DestinationVariable Long studyId,
+            @CurrentUser User currentUser) {
+
+        chatService.openChatModal(studyId, currentUser);
+    }
+
+    @MessageMapping("/studies/{studyId}/modal/close")
+    public void closeChatModal(
+            @DestinationVariable Long studyId,
+            @CurrentUser User currentUser) {
+
+        chatService.closeChatModal(studyId, currentUser);
+    }
+
+    @MessageMapping("/studies/{studyId}/modal/heartbeat")
+    public void modalHeartbeat(
+            @DestinationVariable Long studyId,
+            @CurrentUser User currentUser) {
+
+        chatService.refreshModalState(studyId, currentUser);
     }
 }

--- a/src/main/java/com/pado/domain/chat/dto/response/ChatMessageResponseDto.java
+++ b/src/main/java/com/pado/domain/chat/dto/response/ChatMessageResponseDto.java
@@ -9,15 +9,17 @@ public record ChatMessageResponseDto(
         Long senderId,
         String senderName,
         String content,
+        Long unreadMemberCount,
         LocalDateTime createdAt
 ) {
     
-    public static ChatMessageResponseDto from(ChatMessage chatMessage) {
+    public static ChatMessageResponseDto from(ChatMessage chatMessage, Long unreadMemberCount) {
         return new ChatMessageResponseDto(
                 chatMessage.getId(),
                 chatMessage.getSender().getUser().getId(),
                 chatMessage.getSender().getUser().getNickname(),
                 chatMessage.getContent(),
+                unreadMemberCount,
                 chatMessage.getCreatedAt()
         );
     }

--- a/src/main/java/com/pado/domain/chat/dto/response/LastReadMessageResponseDto.java
+++ b/src/main/java/com/pado/domain/chat/dto/response/LastReadMessageResponseDto.java
@@ -1,0 +1,5 @@
+package com.pado.domain.chat.dto.response;
+
+public record LastReadMessageResponseDto (
+        Long lastReadMessageId
+) {}

--- a/src/main/java/com/pado/domain/chat/dto/response/UnreadCountResponseDto.java
+++ b/src/main/java/com/pado/domain/chat/dto/response/UnreadCountResponseDto.java
@@ -1,0 +1,7 @@
+package com.pado.domain.chat.dto.response;
+
+import lombok.Getter;
+
+public record UnreadCountResponseDto (
+    Long unreadCount
+) {}

--- a/src/main/java/com/pado/domain/chat/entity/LastReadMessage.java
+++ b/src/main/java/com/pado/domain/chat/entity/LastReadMessage.java
@@ -1,6 +1,5 @@
 package com.pado.domain.chat.entity;
 
-import com.pado.domain.basetime.AuditingEntity;
 import com.pado.domain.study.entity.StudyMember;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -11,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "chat_message_read")
+@Table(name = "chat_message_last_read")
 public class LastReadMessage{
     
     @Id

--- a/src/main/java/com/pado/domain/chat/entity/LastReadMessage.java
+++ b/src/main/java/com/pado/domain/chat/entity/LastReadMessage.java
@@ -1,0 +1,37 @@
+package com.pado.domain.chat.entity;
+
+import com.pado.domain.basetime.AuditingEntity;
+import com.pado.domain.study.entity.StudyMember;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "chat_message_read")
+public class LastReadMessage{
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_member_id", nullable = false)
+    private StudyMember studyMember;
+    
+    @Column(name = "last_read_message_id", nullable = false)
+    private Long lastReadMessageId;
+    
+    @Builder
+    public LastReadMessage(StudyMember studyMember, Long lastReadMessageId) {
+        this.studyMember = studyMember;
+        this.lastReadMessageId = lastReadMessageId;
+    }
+    
+    public void updateLastReadMessageId(Long messageId) {
+        this.lastReadMessageId = messageId;
+    }
+}

--- a/src/main/java/com/pado/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/pado/domain/chat/repository/ChatMessageRepository.java
@@ -1,7 +1,12 @@
 package com.pado.domain.chat.repository;
 
 import com.pado.domain.chat.entity.ChatMessage;
+import com.pado.domain.study.entity.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageRepositoryCustom {
+    long countByIdGreaterThanAndStudyId(Long messageId, Long studyId);
+    Optional<ChatMessage> findTopByStudyIdOrderByIdDesc(Long studyId);
 }

--- a/src/main/java/com/pado/domain/chat/repository/LastReadMessageRepository.java
+++ b/src/main/java/com/pado/domain/chat/repository/LastReadMessageRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface LastReadMessageRepository extends JpaRepository<LastReadMessage, Long> {
+public interface LastReadMessageRepository extends JpaRepository<LastReadMessage, Long>, LastReadMessageRepositoryCustom {
     
     Optional<LastReadMessage> findByStudyMember(StudyMember studyMember);
 }

--- a/src/main/java/com/pado/domain/chat/repository/LastReadMessageRepository.java
+++ b/src/main/java/com/pado/domain/chat/repository/LastReadMessageRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LastReadMessageRepository extends JpaRepository<LastReadMessage, Long>, LastReadMessageRepositoryCustom {
     
     Optional<LastReadMessage> findByStudyMember(StudyMember studyMember);
+
+    List<LastReadMessage> findByStudyMemberIn(List<StudyMember> onlineMembers);
 }

--- a/src/main/java/com/pado/domain/chat/repository/LastReadMessageRepository.java
+++ b/src/main/java/com/pado/domain/chat/repository/LastReadMessageRepository.java
@@ -1,0 +1,14 @@
+package com.pado.domain.chat.repository;
+
+import com.pado.domain.chat.entity.LastReadMessage;
+import com.pado.domain.study.entity.StudyMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface LastReadMessageRepository extends JpaRepository<LastReadMessage, Long> {
+    
+    Optional<LastReadMessage> findByStudyMember(StudyMember studyMember);
+}

--- a/src/main/java/com/pado/domain/chat/repository/LastReadMessageRepositoryCustom.java
+++ b/src/main/java/com/pado/domain/chat/repository/LastReadMessageRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.pado.domain.chat.repository;
+
+import java.util.List;
+import java.util.Map;
+
+public interface LastReadMessageRepositoryCustom {
+
+    long countUnreadMembers(Long studyId, Long messageId);
+    Map<Long, Long> getUnreadCountsForMessages(Long studyId, List<Long> messageIds);
+}

--- a/src/main/java/com/pado/domain/chat/repository/LastReadMessageRepositoryCustomImpl.java
+++ b/src/main/java/com/pado/domain/chat/repository/LastReadMessageRepositoryCustomImpl.java
@@ -1,0 +1,60 @@
+package com.pado.domain.chat.repository;
+
+import com.pado.domain.chat.entity.LastReadMessage;
+import com.pado.domain.chat.entity.QLastReadMessage;
+import com.pado.domain.study.entity.QStudyMember;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class LastReadMessageRepositoryCustomImpl implements LastReadMessageRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long countUnreadMembers(Long studyId, Long messageId) {
+        QLastReadMessage lastReadMessage = QLastReadMessage.lastReadMessage;
+        QStudyMember studyMember = QStudyMember.studyMember;
+
+        Long count = queryFactory
+                .select(lastReadMessage.count())
+                .from(lastReadMessage)
+                .join(lastReadMessage.studyMember, studyMember)
+                .where(
+                        studyMember.study.id.eq(studyId),
+                        lastReadMessage.lastReadMessageId.lt(messageId)
+                )
+                .fetchOne();
+
+        return count != null ? count : 0L;
+    }
+
+
+    @Override
+    public Map<Long, Long> getUnreadCountsForMessages(Long studyId, List<Long> messageIds) {
+        QLastReadMessage lastReadMessage = QLastReadMessage.lastReadMessage;
+        QStudyMember studyMember = QStudyMember.studyMember;
+
+        // 스터디의 모든 멤버의 LastReadMessage를 가져옴
+        List<LastReadMessage> allReads = queryFactory
+                .selectFrom(lastReadMessage)
+                .join(lastReadMessage.studyMember, studyMember).fetchJoin()
+                .where(studyMember.study.id.eq(studyId))
+                .fetch();
+
+        // Java에서 계산
+        return messageIds.stream()
+                .collect(Collectors.toMap(
+                        messageId -> messageId,
+                        messageId -> allReads.stream()
+                                .filter(read -> read.getLastReadMessageId() < messageId)
+                                .count()
+                ));
+    }
+}

--- a/src/main/java/com/pado/domain/chat/service/ChatService.java
+++ b/src/main/java/com/pado/domain/chat/service/ChatService.java
@@ -3,12 +3,18 @@ package com.pado.domain.chat.service;
 import com.pado.domain.chat.dto.request.ChatMessageRequestDto;
 import com.pado.domain.chat.dto.response.ChatMessageListResponseDto;
 import com.pado.domain.chat.dto.response.ChatMessageResponseDto;
+import com.pado.domain.chat.dto.response.UnreadCountResponseDto;
 import com.pado.domain.user.entity.User;
 
 public interface ChatService {
 
-    ChatMessageResponseDto sendMessage(Long studyId, ChatMessageRequestDto requestDto, User currentUser);
+    void sendMessage(Long studyId, ChatMessageRequestDto requestDto, User currentUser);
 
     ChatMessageListResponseDto getChatMessages(Long studyId, Long cursor, int size, User currentUser);
 
+    void openChatModal(Long studyId, User currentUser);
+
+    void closeChatModal(Long studyId, User currentUser);
+
+    void refreshModalState(Long studyId, User currentUser);
 }

--- a/src/main/java/com/pado/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/pado/domain/chat/service/ChatServiceImpl.java
@@ -3,13 +3,13 @@ package com.pado.domain.chat.service;
 import com.pado.domain.chat.dto.request.ChatMessageRequestDto;
 import com.pado.domain.chat.dto.response.ChatMessageListResponseDto;
 import com.pado.domain.chat.dto.response.ChatMessageResponseDto;
+import com.pado.domain.chat.dto.response.UnreadCountResponseDto;
 import com.pado.domain.chat.entity.ChatMessage;
+import com.pado.domain.chat.entity.LastReadMessage;
+import com.pado.domain.chat.repository.LastReadMessageRepository;
 import com.pado.domain.chat.repository.ChatMessageRepository;
 import com.pado.domain.study.entity.Study;
 import com.pado.domain.study.entity.StudyMember;
-import com.pado.domain.study.entity.StudyMemberRole;
-import com.pado.domain.study.entity.StudyStatus;
-import com.pado.domain.shared.entity.Region;
 import com.pado.domain.study.repository.StudyMemberRepository;
 import com.pado.domain.study.repository.StudyRepository;
 import com.pado.domain.user.entity.User;
@@ -17,10 +17,12 @@ import com.pado.global.exception.common.BusinessException;
 import com.pado.global.exception.common.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -31,14 +33,15 @@ public class ChatServiceImpl implements ChatService {
     private final ChatMessageRepository chatMessageRepository;
     private final StudyRepository studyRepository;
     private final StudyMemberRepository studyMemberRepository;
+    private final LastReadMessageRepository lastReadRepository;
+    private final RedisChatModalManager modalManager;
+    private final SimpMessagingTemplate messagingTemplate;
 
     @Override
     @Transactional
-    public ChatMessageResponseDto sendMessage(Long studyId, ChatMessageRequestDto requestDto, User currentUser) {
-
-        // 인터셉터에서 1차 검증, 서비스 로직에서 2차 검증
+    public void sendMessage(Long studyId, ChatMessageRequestDto requestDto, User currentUser) {
         validateMessageContent(requestDto.content());
-        
+
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
 
@@ -53,12 +56,24 @@ public class ChatServiceImpl implements ChatService {
 
         ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
 
-        return ChatMessageResponseDto.from(savedMessage);
+        // 현재 채팅방에 접속하고 있는 멤버 대상으로만 메세지 전송 및 마지막 메세지 id 업데이트
+        modalManager.getOpenModalUserIds(studyId).forEach(userId -> {
+
+            ChatMessageResponseDto responseDto = ChatMessageResponseDto.from(savedMessage);
+            messagingTemplate.convertAndSend("/topic/studies/" + studyId + "/chats", responseDto);
+
+            studyMemberRepository.findByStudyIdAndUserId(studyId, userId)
+                    .ifPresent(member -> {
+                        updateLastReadMessage(member, savedMessage.getId());
+                    });
+        });
+
+        // 현재 채팅방에 접속하고 있지 않은 사용자들에게 안읽은 메시지 수 알림
+        sendUnreadCountToClosedModalUsers(studyId);
     }
 
     @Override
     public ChatMessageListResponseDto getChatMessages(Long studyId, Long cursor, int size, User currentUser) {
-        // 2차 검증
         validateStudyMemberPermission(studyId, currentUser);
 
         List<ChatMessage> chatMessages = chatMessageRepository.findChatMessagesWithCursor(studyId, cursor, size);
@@ -84,6 +99,93 @@ public class ChatServiceImpl implements ChatService {
         return ChatMessageListResponseDto.of(messageDtos, hasNext, nextCursor);
     }
 
+    @Override
+    @Transactional
+    public void openChatModal(Long studyId, User currentUser) {
+        validateStudyMemberPermission(studyId, currentUser);
+
+        modalManager.openModal(studyId, currentUser.getId());
+
+        StudyMember studyMember = studyMemberRepository.findByStudyIdAndUserId(studyId, currentUser.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.FORBIDDEN_STUDY_MEMBER_ONLY));
+
+        Optional<ChatMessage> latestMessage = chatMessageRepository.findTopByStudyIdOrderByIdDesc(studyId);
+        Long lastMessageId = latestMessage.isPresent() ? latestMessage.get().getId() : 0L;
+        updateLastReadMessage(studyMember, lastMessageId);
+    }
+
+    @Override
+    @Transactional
+    public void closeChatModal(Long studyId, User currentUser) {
+        validateStudyMemberPermission(studyId, currentUser);
+
+        modalManager.closeModal(studyId, currentUser.getId());
+    }
+
+    @Override
+    public void refreshModalState(Long studyId, User currentUser) {
+        validateStudyMemberPermission(studyId, currentUser);
+
+        modalManager.refreshModal(studyId, currentUser.getId());
+    }
+
+    private void updateLastReadMessage(StudyMember studyMember, Long messageId) {
+
+        LastReadMessage lastRead = lastReadRepository.findByStudyMember(studyMember)
+                .orElse(LastReadMessage.builder()
+                        .studyMember(studyMember)
+                        .lastReadMessageId(0L)
+                        .build());
+
+        lastRead.updateLastReadMessageId(messageId);
+        lastReadRepository.save(lastRead);
+    }
+
+    // 메시지 전송 후 처리 로직
+    private void handleAfterMessageSent(Long studyId, Long messageId) {
+        modalManager.getOpenModalUserIds(studyId).forEach(userId -> {
+
+                studyMemberRepository.findByStudyIdAndUserId(studyId, userId)
+                        .ifPresent(member -> {
+                            updateLastReadMessage(member, messageId);
+                        });
+        });
+
+        // 3. 모달을 열지 않은 사용자들에게 안읽은 메시지 수 알림
+        sendUnreadCountToClosedModalUsers(studyId);
+    }
+
+
+    // 모달을 열지 않은 사용자들에게 안읽은 메시지 수 전송
+    private void sendUnreadCountToClosedModalUsers(Long studyId) {
+        List<StudyMember> allMembers = studyMemberRepository.findByStudyId(studyId);
+
+        allMembers.forEach(member -> {
+            User user = member.getUser();
+
+            if (!modalManager.isModalOpen(studyId, user.getId())) {
+
+                LastReadMessage lastRead = lastReadRepository.findByStudyMember(member)
+                        .orElse(LastReadMessage.builder()
+                                .studyMember(member)
+                                .lastReadMessageId(0L)
+                                .build());
+
+                long unreadCount = chatMessageRepository.countByIdGreaterThanAndStudyId(lastRead.getLastReadMessageId(), studyId);
+
+                if (unreadCount > 0) {
+                    UnreadCountResponseDto response = new UnreadCountResponseDto(unreadCount);
+
+                    messagingTemplate.convertAndSendToUser(
+                            user.getEmail(),
+                            "/queue/studies/" + studyId + "/unread",
+                            response
+                    );
+                }
+            }
+        });
+    }
+
     private void validateMessageContent(String content) {
         if (content == null || content.trim().isEmpty()) {
             throw new BusinessException(ErrorCode.CHAT_MESSAGE_NOT_FOUND);
@@ -94,7 +196,7 @@ public class ChatServiceImpl implements ChatService {
         }
     }
 
-    public void validateStudyMemberPermission(Long studyId, User currentUser) {
+    private void validateStudyMemberPermission(Long studyId, User currentUser) {
         if (!studyRepository.existsById(studyId)) {
             throw new BusinessException(ErrorCode.STUDY_NOT_FOUND);
         }

--- a/src/main/java/com/pado/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/pado/domain/chat/service/ChatServiceImpl.java
@@ -19,6 +19,7 @@ import com.pado.global.exception.common.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -80,8 +81,8 @@ public class ChatServiceImpl implements ChatService {
         ChatMessageResponseDto responseDto = ChatMessageResponseDto.from(savedMessage, unreadMemberCount);
         messagingTemplate.convertAndSend("/topic/studies/" + studyId + "/chats", responseDto);
 
-        // 현재 채팅방에 접속하고 있지 않은 사용자들에게 안읽은 메시지 수 알림
-        sendUnreadCountToClosedModalUsers(studyId);
+        // 현재 채팅방에 접속하고 있지 않은 사용자들에게 안읽은 메시지 수 알림을 비동기 처리
+        sendUnreadCountToClosedModalUsersAsync(studyId);
     }
 
     @Override
@@ -161,6 +162,13 @@ public class ChatServiceImpl implements ChatService {
         validateStudyMemberPermission(studyId, currentUser);
 
         modalManager.refreshModal(studyId, currentUser.getId());
+    }
+
+    // 모달을 열지 않은 사용자들에게 안읽은 메시지 수 전송을 비동기 처리
+    @Async
+    public void sendUnreadCountToClosedModalUsersAsync(Long studyId){
+
+        sendUnreadCountToClosedModalUsers(studyId);
     }
 
     // 모달을 열지 않은 사용자들에게 안읽은 메시지 수 전송

--- a/src/main/java/com/pado/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/pado/domain/chat/service/ChatServiceImpl.java
@@ -133,14 +133,16 @@ public class ChatServiceImpl implements ChatService {
 
         // 현재 채팅방에서 가장 최신 메시지 아이디 추출
         Optional<ChatMessage> latestMessage = chatMessageRepository.findTopByStudyIdOrderByIdDesc(studyId);
-        long lastestChatMessageId = latestMessage.isPresent() ? latestMessage.get().getId() : 0L;
+        long latestChatMessageId = chatMessageRepository.findTopByStudyIdOrderByIdDesc(studyId)
+                .map(ChatMessage::getId)
+                .orElse(0L);
 
         // 모달을 킨 유저가 가장 마지막으로 읽었던 메세지 아이디 추출
         LastReadMessage lastReadMessage = lastReadRepository.findByStudyMember(studyMember)
                         .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_LAST_READ_CHAT));
         long lastReadMessageId = lastReadMessage.getLastReadMessageId();
 
-        lastReadMessage.updateLastReadMessageId(lastestChatMessageId);
+        lastReadMessage.updateLastReadMessageId(latestChatMessageId);
 
         // 모달을 킨 유저가 가장 마지막으로 읽었던 메세지 아이디 전송
         // 프론트에서 이보다 큰 메세지들의 읽지 않은 멤버 수에 -1 수행

--- a/src/main/java/com/pado/domain/chat/service/RedisChatModalManager.java
+++ b/src/main/java/com/pado/domain/chat/service/RedisChatModalManager.java
@@ -1,0 +1,72 @@
+package com.pado.domain.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class RedisChatModalManager {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String MODAL_KEY_PREFIX = "chat:modal:";
+    private static final long MODAL_TTL = 300; // 5분 (초 단위)
+
+
+    // 채팅 모달 열기
+    // Redis에 "chat:modal:{studyId}:{userId}" = "true" 저장 (TTL 5분)
+    public void openModal(Long studyId, Long userId) {
+        String key = getModalKey(studyId, userId);
+        redisTemplate.opsForValue().set(key, "true", MODAL_TTL, TimeUnit.SECONDS);
+    }
+
+
+    // 채팅 모달 닫기
+    // Redis에서 키 삭제
+    public void closeModal(Long studyId, Long userId) {
+        String key = getModalKey(studyId, userId);
+        redisTemplate.delete(key);
+    }
+
+
+    // 모달이 열려있는지 확인
+    public boolean isModalOpen(Long studyId, Long userId) {
+        String key = getModalKey(studyId, userId);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    // 모달이 열려있는 상태면 주기적으로 TTL 갱신
+    public void refreshModal(Long studyId, Long userId) {
+        String key = getModalKey(studyId, userId);
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
+            redisTemplate.expire(key, MODAL_TTL, TimeUnit.SECONDS);
+        }
+    }
+
+
+    // 특정 스터디에서 모달이 열린 모든 사용자 ID 조회
+    public Set<Long> getOpenModalUserIds(Long studyId) {
+        String pattern = MODAL_KEY_PREFIX + studyId + ":*";
+        Set<String> keys = redisTemplate.keys(pattern);
+
+        if (keys.isEmpty()) {
+            return Set.of();
+        }
+
+        return keys.stream()
+                .map(key -> {
+                    String[] parts = key.split(":");
+                    return Long.parseLong(parts[parts.length - 1]);
+                })
+                .collect(Collectors.toSet());
+    }
+
+    private String getModalKey(Long studyId, Long userId) {
+        return MODAL_KEY_PREFIX + studyId + ":" + userId;
+    }
+}

--- a/src/main/java/com/pado/domain/study/repository/StudyMemberRepository.java
+++ b/src/main/java/com/pado/domain/study/repository/StudyMemberRepository.java
@@ -11,10 +11,19 @@ import org.springframework.data.repository.query.Param;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
 
     Optional<StudyMember> findByStudyAndUser(Study study, User user);
+
+    @Query("""
+            select sm 
+            from StudyMember sm 
+            join fetch sm.user 
+            where sm.study.id = :studyId and sm.user.id IN :userIds
+        """)
+    List<StudyMember> findByStudyIdAndUserIdIn(@Param("studyId") Long studyId, @Param("userIds") Set<Long> userIds);
 
     int countByStudyId(long studyId);
 

--- a/src/main/java/com/pado/domain/study/service/StudyServiceImpl.java
+++ b/src/main/java/com/pado/domain/study/service/StudyServiceImpl.java
@@ -65,11 +65,7 @@ public class StudyServiceImpl implements StudyService {
         StudyMember savedLeader = studyMemberRepository.save(leaderMember);
 
         // 멤버 새로 생성과 함께 해당 유저가 가장 마지막에 읽은 아이디 엔티티를 만들어 채팅방 기능이 정상적으로 작동하도록 구현
-        // 채팅방에 아무런 채팅이 없으면 0, 아니라면 가장 최신의 메세지 아이디를 가짐
-        Optional<ChatMessage> lastestMessage = chatMessageRepository.findTopByStudyIdOrderByIdDesc(savedStudy.getId());
-        long lastestMessageId = lastestMessage.isPresent() ? lastestMessage.get().getId() : 0L;
-
-        LastReadMessage lastReadMessage = new LastReadMessage(savedLeader, lastestMessageId);
+        LastReadMessage lastReadMessage = new LastReadMessage(savedLeader, 0L);
         lastReadMessageRepository.save(lastReadMessage);
     }
 

--- a/src/main/java/com/pado/domain/study/service/StudyServiceImpl.java
+++ b/src/main/java/com/pado/domain/study/service/StudyServiceImpl.java
@@ -1,5 +1,9 @@
 package com.pado.domain.study.service;
 
+import com.pado.domain.chat.entity.ChatMessage;
+import com.pado.domain.chat.entity.LastReadMessage;
+import com.pado.domain.chat.repository.ChatMessageRepository;
+import com.pado.domain.chat.repository.LastReadMessageRepository;
 import com.pado.domain.shared.entity.Category;
 import com.pado.domain.shared.entity.Region;
 import com.pado.domain.study.dto.request.StudyCreateRequestDto;
@@ -20,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,6 +33,8 @@ public class StudyServiceImpl implements StudyService {
 
     private final StudyRepository studyRepository;
     private final StudyMemberRepository studyMemberRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final LastReadMessageRepository lastReadMessageRepository;
 
     private static final int MAX_PAGE_SIZE = 50;
 
@@ -54,8 +61,16 @@ public class StudyServiceImpl implements StudyService {
                 .role(StudyMemberRole.LEADER)
                 .build();
 
-        studyRepository.save(newStudy);
-        studyMemberRepository.save(leaderMember);
+        Study savedStudy = studyRepository.save(newStudy);
+        StudyMember savedLeader = studyMemberRepository.save(leaderMember);
+
+        // 멤버 새로 생성과 함께 해당 유저가 가장 마지막에 읽은 아이디 엔티티를 만들어 채팅방 기능이 정상적으로 작동하도록 구현
+        // 채팅방에 아무런 채팅이 없으면 0, 아니라면 가장 최신의 메세지 아이디를 가짐
+        Optional<ChatMessage> lastestMessage = chatMessageRepository.findTopByStudyIdOrderByIdDesc(savedStudy.getId());
+        long lastestMessageId = lastestMessage.isPresent() ? lastestMessage.get().getId() : 0L;
+
+        LastReadMessage lastReadMessage = new LastReadMessage(savedLeader, lastestMessageId);
+        lastReadMessageRepository.save(lastReadMessage);
     }
 
     public List<MyStudyResponseDto> findMyStudies(Long userId) {

--- a/src/main/java/com/pado/global/auth/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/pado/global/auth/websocket/StompAuthChannelInterceptor.java
@@ -101,7 +101,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     }
 
     private Long extractStudyIdFromDestination(String destination) {
-        Pattern pattern = Pattern.compile("/topic/studies/(\\d+)/chats");
+        Pattern pattern = Pattern.compile("/topic/studies/(\\d+)/.*");
         Matcher matcher = pattern.matcher(destination);
         if (matcher.find()) {
             return Long.parseLong(matcher.group(1));

--- a/src/main/java/com/pado/global/config/WebSocketConfig.java
+++ b/src/main/java/com/pado/global/config/WebSocketConfig.java
@@ -37,7 +37,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // WebSocket 연결 엔드포인트
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("*"); // CORS 설정
+                .setAllowedOriginPatterns("*") // CORS 설정
+                .withSockJS();
     }
 
     @Override

--- a/src/main/java/com/pado/global/config/WebSocketConfig.java
+++ b/src/main/java/com/pado/global/config/WebSocketConfig.java
@@ -27,10 +27,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         // 클라이언트에서 메시지를 구독할 때 사용할 prefix
-        registry.enableSimpleBroker("/topic");
+        registry.enableSimpleBroker("/topic", "/queue");
         
         // 클라이언트에서 메시지를 전송할 때 사용할 prefix
         registry.setApplicationDestinationPrefixes("/app");
+
+        // 개인 메세지용 prefix
+        registry.setUserDestinationPrefix("/user");
     }
 
     @Override

--- a/src/main/java/com/pado/global/exception/common/ErrorCode.java
+++ b/src/main/java/com/pado/global/exception/common/ErrorCode.java
@@ -105,6 +105,7 @@ public enum ErrorCode {
     INVALID_SUBSCRIBE_PATH(HttpStatus.BAD_REQUEST, "INVALID_SUBSCRIBE_PATH", "구독 경로가 잘못되었습니다."),
     CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_MESSAGE_NOT_FOUND", "채팅 메시지를 찾을 수 없습니다."),
     CHAT_MESSAGE_TOO_LONG(HttpStatus.BAD_REQUEST, "CHAT_MESSAGE_TOO_LONG", "메시지가 너무 깁니다."),
+    NOT_FOUND_LAST_READ_CHAT(HttpStatus.NOT_FOUND, "NOT_FOUND_LAST_READ_CHAT", "해당 유저가 가장 마지막으로 읽는 메세지를 찾을 수 없습니다."),
     WEBSOCKET_CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WEBSOCKET_CONNECTION_FAILED", "웹소켓 연결에 실패했습니다.");
 
     public final HttpStatus status;

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -231,7 +231,7 @@ CREATE TABLE IF NOT EXISTS chapter (
     CONSTRAINT fk_chapter_study FOREIGN KEY (study_id) REFERENCES study(id) ON DELETE CASCADE
 );
 
-CREATE TABLE chat_message_read (
+CREATE TABLE chat_message_last_read (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     study_member_id BIGINT NOT NULL,
     last_read_message_id BIGINT NOT NULL,

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -230,3 +230,10 @@ CREATE TABLE IF NOT EXISTS chapter (
     completed BOOLEAN NOT NULL DEFAULT FALSE,
     CONSTRAINT fk_chapter_study FOREIGN KEY (study_id) REFERENCES study(id) ON DELETE CASCADE
 );
+
+CREATE TABLE chat_message_read (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    study_member_id BIGINT NOT NULL,
+    last_read_message_id BIGINT NOT NULL,
+    CONSTRAINT chat_message_read_member FOREIGN KEY (study_member_id) REFERENCES study_member (id) ON DELETE CASCADE
+);

--- a/src/main/resources/static/chat-test.html
+++ b/src/main/resources/static/chat-test.html
@@ -185,8 +185,8 @@
             
             log('WebSocket 연결 시도...');
             
-            // WebSocket + STOMP 연결 (SockJS 없이 순수 WebSocket 사용)
-            const socket = new WebSocket(`ws://localhost:8080/ws`);
+            // WebSocket + STOMP 연결 (SockJS 사용)
+            const socket = new SockJS(`http://localhost:8080/ws`);
             stompClient = Stomp.over(socket);
             
             // 헤더에 인증 토큰 추가

--- a/src/main/resources/static/chat-test.html
+++ b/src/main/resources/static/chat-test.html
@@ -3,12 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pado 채팅 테스트</title>
+    <title>Pado 채팅 테스트 (Redis 모달 관리 + 안 읽은 멤버 수)</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.6.1/sockjs.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
     <style>
         body {
             font-family: Arial, sans-serif;
-            max-width: 800px;
+            max-width: 900px;
             margin: 0 auto;
             padding: 20px;
         }
@@ -17,6 +18,20 @@
             border-radius: 8px;
             padding: 20px;
             margin-bottom: 20px;
+        }
+        .modal-status {
+            padding: 10px;
+            border-radius: 4px;
+            margin-bottom: 10px;
+            font-weight: bold;
+        }
+        .modal-status.open {
+            background-color: #d1ecf1;
+            color: #0c5460;
+        }
+        .modal-status.closed {
+            background-color: #f8d7da;
+            color: #721c24;
         }
         .chat-messages {
             height: 400px;
@@ -31,14 +46,36 @@
             padding: 8px;
             border-radius: 4px;
             background-color: white;
+            position: relative;
         }
         .message-header {
             font-size: 12px;
             color: #666;
             margin-bottom: 5px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
         }
         .message-content {
             font-size: 14px;
+        }
+        .unread-badge {
+            background-color: #ff4444;
+            color: white;
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-size: 11px;
+            font-weight: bold;
+            margin-left: 10px;
+        }
+        .unread-count {
+            background-color: #ff4444;
+            color: white;
+            padding: 8px 15px;
+            border-radius: 20px;
+            margin: 10px 0;
+            font-weight: bold;
+            display: inline-block;
         }
         .input-group {
             display: flex;
@@ -56,6 +93,7 @@
             border: none;
             border-radius: 4px;
             cursor: pointer;
+            font-weight: bold;
         }
         .btn-primary {
             background-color: #007bff;
@@ -67,6 +105,14 @@
         }
         .btn-danger {
             background-color: #dc3545;
+            color: white;
+        }
+        .btn-warning {
+            background-color: #ffc107;
+            color: black;
+        }
+        .btn-info {
+            background-color: #17a2b8;
             color: white;
         }
         .status {
@@ -91,256 +137,481 @@
             font-family: monospace;
             font-size: 12px;
         }
+        .highlight {
+            background-color: yellow;
+            padding: 2px 4px;
+        }
+        .info-box {
+            background-color: #e7f3ff;
+            border-left: 4px solid #007bff;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        .info-box h4 {
+            margin-top: 0;
+            color: #007bff;
+        }
     </style>
 </head>
 <body>
-    <h1>🌊 Pado 채팅 시스템 테스트</h1>
+<h1>🌊 Pado 채팅 테스트 (Redis 모달 관리 + 안 읽은 멤버 수)</h1>
+
+<div class="container">
+    <h2>연결 설정</h2>
+    <div class="input-group">
+        <input type="number" id="studyId" placeholder="스터디 ID (예: 1)" value="1">
+        <input type="text" id="authToken" placeholder="JWT 토큰 (Bearer 제외)">
+    </div>
+    <div class="input-group">
+        <button class="btn btn-success" onclick="connect()">WebSocket 연결</button>
+        <button class="btn btn-danger" onclick="disconnect()">연결 해제</button>
+    </div>
+    <div id="connectionStatus" class="status disconnected">연결되지 않음</div>
+</div>
+
+<div class="container">
+    <h2>채팅 모달 제어 (Redis)</h2>
+    <div class="input-group">
+        <button class="btn btn-info" onclick="openModal()">📂 모달 열기</button>
+        <button class="btn btn-warning" onclick="closeModal()">📁 모달 닫기</button>
+        <button class="btn btn-primary" onclick="loadChatHistory()">📋 채팅 기록</button>
+    </div>
+    <div id="modalStatus" class="modal-status closed">모달 상태: 닫힘</div>
+    <div id="unreadCount" style="display: none;">
+        <span class="unread-count">안읽은 메시지: 0개</span>
+    </div>
     
-    <div class="container">
-        <h2>연결 설정</h2>
-        <div class="input-group">
-            <input type="number" id="studyId" placeholder="스터디 ID (예: 1)" value="1">
-            <input type="text" id="authToken" placeholder="JWT 토큰 (Bearer 제외)">
-        </div>
-        <div class="input-group">
-            <button class="btn btn-success" onclick="connect()">연결</button>
-            <button class="btn btn-danger" onclick="disconnect()">연결 해제</button>
-            <button class="btn btn-primary" onclick="loadChatHistory()">채팅 기록 불러오기</button>
-        </div>
-        <div id="connectionStatus" class="status disconnected">연결되지 않음</div>
-    </div>
-
-    <div class="container">
-        <h2>채팅</h2>
-        <div id="chatMessages" class="chat-messages"></div>
-        <div class="input-group">
-            <input type="text" id="messageInput" placeholder="메시지를 입력하세요..." maxlength="1000">
-            <button class="btn btn-primary" onclick="sendMessage()">전송</button>
-        </div>
-    </div>
-
-    <div class="container">
-        <h2>로그</h2>
-        <div id="logs" class="logs"></div>
-        <button class="btn btn-primary" onclick="clearLogs()">로그 지우기</button>
-    </div>
-
-    <div class="container">
-        <h2>사용법</h2>
-        <ol>
-            <li><strong>JWT 토큰 발급:</strong> 로그인 API로 토큰을 받아서 위에 입력</li>
-            <li><strong>스터디 ID:</strong> 테스트할 스터디의 ID 입력</li>
-            <li><strong>연결:</strong> "연결" 버튼 클릭</li>
-            <li><strong>메시지 전송:</strong> 메시지 입력 후 "전송" 버튼 클릭</li>
-            <li><strong>DB 확인:</strong> "채팅 기록 불러오기"로 저장된 메시지 확인</li>
-        </ol>
-        <p><strong>API 엔드포인트:</strong></p>
+    <div class="info-box">
+        <h4>✨ 새로운 기능: 안 읽은 멤버 수 표시</h4>
+        <p>각 메시지 옆에 <span class="unread-badge">3명 안 읽음</span> 형태로 표시됩니다!</p>
         <ul>
-            <li>WebSocket: <code>ws://localhost:8080/ws</code></li>
-            <li>채팅 기록: <code>GET /api/studies/{studyId}/chats</code></li>
+            <li>💬 메시지 전송 시: 자동으로 안 읽은 멤버 수 표시</li>
+            <li>📖 다른 사용자가 읽으면: 실시간으로 숫자 감소</li>
+            <li>📋 채팅 기록 불러오기: 현재 시점의 안 읽은 멤버 수 표시</li>
         </ul>
     </div>
+    
+    <p style="font-size: 14px; color: #666; margin-top: 10px;">
+        💡 모달이 닫힌 상태에서 메시지가 오면 안읽은 메시지 수가 자동으로 표시됩니다.
+    </p>
+    <p style="font-size: 12px; color: #666;">
+        💡 모달을 열면 자동으로 최신 메시지까지 읽음 처리됩니다.<br>
+        💡 모달을 열면 Heartbeat가 자동으로 전송됩니다 (4분마다).
+    </p>
+</div>
 
-    <script>
-        let stompClient = null;
-        let currentStudyId = null;
+<div class="container">
+    <h2>채팅</h2>
+    <div id="chatMessages" class="chat-messages"></div>
+    <div class="input-group">
+        <input type="text" id="messageInput" placeholder="메시지를 입력하세요..." maxlength="1000">
+        <button class="btn btn-primary" onclick="sendMessage()">전송</button>
+    </div>
+</div>
 
-        function log(message) {
-            const logs = document.getElementById('logs');
-            const timestamp = new Date().toLocaleTimeString();
-            logs.innerHTML += `[${timestamp}] ${message}\n`;
-            logs.scrollTop = logs.scrollHeight;
+<div class="container">
+    <h2>로그</h2>
+    <div id="logs" class="logs"></div>
+    <button class="btn btn-primary" onclick="clearLogs()">로그 지우기</button>
+</div>
+
+<div class="container">
+    <h2>동작 방식</h2>
+    <ol>
+        <li><strong>WebSocket 연결:</strong> "WebSocket 연결" 버튼으로 서버와 연결</li>
+        <li><strong>모달 열기:</strong> "모달 열기" 버튼 클릭 → Redis에 상태 저장 + 읽음 처리</li>
+        <li><strong>메시지 전송:</strong> 채팅 입력 후 "전송" 버튼 클릭</li>
+        <li><strong>모달 닫기:</strong> "모달 닫기" 버튼 클릭 → Redis에서 상태 삭제</li>
+        <li><strong>안읽은 메시지:</strong> 모달이 닫힌 상태에서 메시지가 오면 자동으로 알림</li>
+        <li><strong>안 읽은 멤버 수:</strong> 각 메시지 옆에 실시간으로 표시</li>
+    </ol>
+
+    <h3>Redis 기반 모달 관리 특징</h3>
+    <ul>
+        <li>✅ Redis에 "chat:modal:{studyId}:{userId}" 키로 모달 상태 저장</li>
+        <li>✅ TTL 5분 설정 (자동 만료)</li>
+        <li>✅ Heartbeat로 4분마다 TTL 갱신 (모달 열려있는 동안)</li>
+        <li>✅ 멀티 서버 환경에서도 동일한 상태 공유</li>
+        <li>✅ 모달 열린 사용자: 메시지 자동 읽음 처리</li>
+        <li>✅ 모달 닫힌 사용자: 안읽은 메시지 수 알림 수신 (자동)</li>
+        <li>✨ <strong>안 읽은 멤버 수 실시간 표시 (카카오톡 스타일)</strong></li>
+    </ul>
+
+    <h3>테스트 시나리오</h3>
+    <ol>
+        <li><strong>단일 사용자:</strong>
+            <ul>
+                <li>모달 열기 → 메시지 전송 → 자동 읽음 처리 확인</li>
+                <li>모달 닫기 → 다른 탭에서 메시지 전송 → 안읽은 수 알림 확인</li>
+            </ul>
+        </li>
+        <li><strong>여러 사용자 (다른 브라우저/탭):</strong>
+            <ul>
+                <li>사용자 A: 모달 열고 있음</li>
+                <li>사용자 B: 모달 닫고 있음</li>
+                <li>사용자 C: 메시지 전송</li>
+                <li>결과: A는 자동 읽음, B는 안읽은 메시지 수 알림, 메시지 옆에 "1명 안 읽음" 표시</li>
+            </ul>
+        </li>
+        <li><strong>안 읽은 멤버 수 테스트:</strong>
+            <ul>
+                <li>여러 탭에서 서로 다른 사용자로 접속</li>
+                <li>일부는 모달 열기, 일부는 모달 닫기</li>
+                <li>메시지 전송 후 안 읽은 멤버 수 확인</li>
+                <li>다른 사용자가 모달을 열면 숫자가 실시간으로 감소하는지 확인</li>
+            </ul>
+        </li>
+    </ol>
+
+    <p><strong>API 엔드포인트:</strong></p>
+    <ul>
+        <li>WebSocket: <code>http://localhost:8080/ws</code> (SockJS)</li>
+        <li>채팅 기록: <code>GET /api/studies/{studyId}/chats</code></li>
+    </ul>
+
+    <p><strong>WebSocket 메시지:</strong></p>
+    <ul>
+        <li>메시지 전송: <code>/app/studies/{studyId}/chats</code></li>
+        <li>모달 열기: <code>/app/studies/{studyId}/modal/open</code></li>
+        <li>모달 닫기: <code>/app/studies/{studyId}/modal/close</code></li>
+        <li>Heartbeat: <code>/app/studies/{studyId}/modal/heartbeat</code></li>
+    </ul>
+
+    <p><strong>WebSocket 구독:</strong></p>
+    <ul>
+        <li>채팅 메시지: <code>/topic/studies/{studyId}/chats</code> (unreadMemberCount 포함)</li>
+        <li>읽음 상태 업데이트: <code>/topic/studies/{studyId}/unread</code> (lastReadMessageId)</li>
+        <li>안읽은 메시지 수: <code>/user/queue/studies/{studyId}/unread</code> (개인 메시지, 자동)</li>
+    </ul>
+</div>
+
+<script>
+    let stompClient = null;
+    let currentStudyId = null;
+    let isModalOpen = false;
+    let heartbeatInterval = null;
+    let messageMap = new Map(); // messageId -> DOM element 매핑
+
+    function log(message, highlight = false) {
+        const logs = document.getElementById('logs');
+        const timestamp = new Date().toLocaleTimeString();
+        const className = highlight ? 'class="highlight"' : '';
+        logs.innerHTML += `<span ${className}>[${timestamp}] ${message}</span>\n`;
+        logs.scrollTop = logs.scrollHeight;
+    }
+
+    function clearLogs() {
+        document.getElementById('logs').innerHTML = '';
+    }
+
+    function updateConnectionStatus(connected) {
+        const status = document.getElementById('connectionStatus');
+        if (connected) {
+            status.className = 'status connected';
+            status.textContent = `스터디 ${currentStudyId} WebSocket 연결됨 (SockJS + Redis)`;
+        } else {
+            status.className = 'status disconnected';
+            status.textContent = '연결되지 않음';
+        }
+    }
+
+    function updateModalStatus(open) {
+        isModalOpen = open;
+        const status = document.getElementById('modalStatus');
+        if (open) {
+            status.className = 'modal-status open';
+            status.textContent = '모달 상태: 열림 (Redis에 저장됨)';
+        } else {
+            status.className = 'modal-status closed';
+            status.textContent = '모달 상태: 닫힘 (Redis에서 삭제됨)';
+        }
+    }
+
+    function updateUnreadCount(count) {
+        const unreadDiv = document.getElementById('unreadCount');
+        if (count > 0) {
+            unreadDiv.innerHTML = `<span class="unread-count">안읽은 메시지: ${count}개</span>`;
+            unreadDiv.style.display = 'block';
+        } else {
+            unreadDiv.style.display = 'none';
+        }
+    }
+
+    function startHeartbeat() {
+        if (heartbeatInterval) {
+            clearInterval(heartbeatInterval);
         }
 
-        function clearLogs() {
-            document.getElementById('logs').innerHTML = '';
+        // 4분마다 heartbeat 전송 (TTL이 5분이므로)
+        heartbeatInterval = setInterval(() => {
+            if (stompClient && stompClient.connected && isModalOpen) {
+                stompClient.send(`/app/studies/${currentStudyId}/modal/heartbeat`, {}, JSON.stringify({}));
+                log('💓 Heartbeat 전송 (Redis TTL 갱신)');
+            }
+        }, 240000); // 4분
+    }
+
+    function stopHeartbeat() {
+        if (heartbeatInterval) {
+            clearInterval(heartbeatInterval);
+            heartbeatInterval = null;
+            log('💔 Heartbeat 중지');
+        }
+    }
+
+    function connect() {
+        const studyId = document.getElementById('studyId').value;
+        const authToken = document.getElementById('authToken').value;
+
+        if (!studyId) {
+            alert('스터디 ID를 입력해주세요');
+            return;
         }
 
-        function updateConnectionStatus(connected) {
-            const status = document.getElementById('connectionStatus');
-            if (connected) {
-                status.className = 'status connected';
-                status.textContent = `스터디 ${currentStudyId} 채팅방에 연결됨`;
-            } else {
-                status.className = 'status disconnected';
-                status.textContent = '연결되지 않음';
-            }
+        if (!authToken) {
+            alert('JWT 토큰을 입력해주세요');
+            return;
         }
 
-        function connect() {
-            const studyId = document.getElementById('studyId').value;
-            const authToken = document.getElementById('authToken').value;
+        currentStudyId = studyId;
 
-            if (!studyId) {
-                alert('스터디 ID를 입력해주세요');
-                return;
-            }
+        log('🔌 SockJS + WebSocket 연결 시도...');
 
-            if (!authToken) {
-                alert('JWT 토큰을 입력해주세요');
-                return;
-            }
+        const socket = new SockJS('/ws');
+        stompClient = Stomp.over(socket);
 
-            currentStudyId = studyId;
-            
-            log('WebSocket 연결 시도...');
-            
-            // WebSocket + STOMP 연결 (SockJS 사용)
-            const socket = new SockJS(`http://localhost:8080/ws`);
-            stompClient = Stomp.over(socket);
-            
-            // 헤더에 인증 토큰 추가
-            const headers = {
-                'Authorization': `Bearer ${authToken}`
-            };
-
-            stompClient.connect(headers, function(frame) {
-                log('WebSocket 연결 성공: ' + frame);
-                updateConnectionStatus(true);
-                
-                // 스터디 채팅방 구독
-                stompClient.subscribe(`/topic/studies/${studyId}/chats`, function(message) {
-                    const chatMessage = JSON.parse(message.body);
-                    displayMessage(chatMessage);
-                    log('메시지 수신: ' + JSON.stringify(chatMessage));
-                });
-
-                // 에러 메시지 구독
-                stompClient.subscribe('/user/queue/errors', function(message) {
-                    const error = JSON.parse(message.body);
-                    log('에러 수신: ' + JSON.stringify(error));
-                    alert(`에러: ${error.message}`);
-                });
-
-                log(`스터디 ${studyId} 채팅방 구독 완료`);
-                
-            }, function(error) {
-                log('WebSocket 연결 실패: ' + error);
-                updateConnectionStatus(false);
-                alert('연결 실패: ' + error);
-            });
-        }
-
-        function disconnect() {
-            if (stompClient !== null) {
-                stompClient.disconnect();
-                log('WebSocket 연결 해제');
-            }
-            updateConnectionStatus(false);
-            currentStudyId = null;
-        }
-
-        function sendMessage() {
-            const messageInput = document.getElementById('messageInput');
-            const content = messageInput.value.trim();
-
-            if (!content) {
-                alert('메시지를 입력해주세요');
-                return;
-            }
-
-            if (!stompClient || !stompClient.connected) {
-                alert('먼저 채팅방에 연결해주세요');
-                return;
-            }
-
-            const message = {
-                content: content
-            };
-
-            log(`메시지 전송 시도: ${content}`);
-            
-            // 메시지 전송
-            stompClient.send(`/app/studies/${currentStudyId}/chats`, {}, JSON.stringify(message));
-            
-            messageInput.value = '';
-        }
-
-        function displayMessage(message) {
-            const chatMessages = document.getElementById('chatMessages');
-            const messageDiv = document.createElement('div');
-            messageDiv.className = 'message';
-            
-            const timestamp = new Date(message.createdAt).toLocaleString();
-            
-            messageDiv.innerHTML = `
-                <div class="message-header">
-                    <strong>${message.senderName}</strong> - ${timestamp}
-                </div>
-                <div class="message-content">${escapeHtml(message.content)}</div>
-            `;
-            
-            chatMessages.appendChild(messageDiv);
-            chatMessages.scrollTop = chatMessages.scrollHeight;
-        }
-
-        function escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
-        }
-
-        async function loadChatHistory() {
-            const authToken = document.getElementById('authToken').value;
-            const studyId = document.getElementById('studyId').value;
-
-            if (!authToken || !studyId) {
-                alert('스터디 ID와 JWT 토큰을 입력해주세요');
-                return;
-            }
-
-            try {
-                log('채팅 기록 불러오는 중...');
-                
-                const response = await fetch(`/api/studies/${studyId}/chats?size=50`, {
-                    headers: {
-                        'Authorization': `Bearer ${authToken}`,
-                        'Content-Type': 'application/json'
-                    }
-                });
-
-                if (response.ok) {
-                    const data = await response.json();
-                    log(`채팅 기록 ${data.messages.length}개 불러옴`);
-                    
-                    // 기존 메시지 지우기
-                    document.getElementById('chatMessages').innerHTML = '';
-                    
-                    // 메시지 표시 (오래된 순서대로)
-                    data.messages.reverse().forEach(message => {
-                        displayMessage(message);
-                    });
-                    
-                } else {
-                    const errorText = await response.text();
-                    log(`채팅 기록 불러오기 실패: ${response.status} ${errorText}`);
-                    alert(`채팅 기록 불러오기 실패: ${response.status}`);
-                }
-            } catch (error) {
-                log('채팅 기록 불러오기 에러: ' + error);
-                alert('채팅 기록 불러오기 에러: ' + error.message);
-            }
-        }
-
-        // Enter 키로 메시지 전송
-        document.getElementById('messageInput').addEventListener('keypress', function(e) {
-            if (e.key === 'Enter') {
-                sendMessage();
-            }
-        });
-
-        // 페이지 로드 시
-        window.onload = function() {
-            log('채팅 테스트 페이지 로드됨');
-            log('사용 전에 JWT 토큰과 스터디 ID를 입력하세요');
+        const headers = {
+            'Authorization': `Bearer ${authToken}`
         };
 
-        // 페이지 종료 시 연결 해제
-        window.addEventListener('beforeunload', function() {
-            if (stompClient !== null) {
-                stompClient.disconnect();
+        stompClient.connect(headers, function(frame) {
+            log('✅ WebSocket 연결 성공!');
+            updateConnectionStatus(true);
+
+            // 채팅 메시지 구독
+            stompClient.subscribe(`/topic/studies/${studyId}/chats`, function(message) {
+                const chatMessage = JSON.parse(message.body);
+                displayMessage(chatMessage);
+                log(`💬 채팅 메시지 수신: ${chatMessage.senderName} (안 읽은 멤버: ${chatMessage.unreadMemberCount}명)`);
+            });
+
+            // 읽음 상태 업데이트 구독 (누군가 모달을 열었을 때)
+            stompClient.subscribe(`/topic/studies/${studyId}/unread`, function(message) {
+                const readData = JSON.parse(message.body);
+                updateUnreadCountForMessagesAfter(readData.lastReadMessageId);
+                log(`📖 읽음 상태 업데이트: messageId ${readData.lastReadMessageId} 이후 메시지 업데이트`, true);
+            });
+
+            // 안읽은 메시지 수 구독 (개인 메시지)
+            stompClient.subscribe(`/user/queue/studies/${studyId}/unread`, function(message) {
+                const unreadData = JSON.parse(message.body);
+                updateUnreadCount(unreadData.unreadCount);
+                log(`🔔 안읽은 메시지 수 자동 수신: ${unreadData.unreadCount}개`, true);
+            });
+
+            // 에러 메시지 구독
+            stompClient.subscribe('/user/queue/errors', function(message) {
+                const error = JSON.parse(message.body);
+                log('❌ 에러: ' + JSON.stringify(error), true);
+                alert(`에러: ${error.message}`);
+            });
+
+            log(`📡 스터디 ${studyId} 구독 완료 (채팅, 읽음 상태, 안읽은 수)`);
+
+        }, function(error) {
+            log('❌ WebSocket 연결 실패: ' + error, true);
+            updateConnectionStatus(false);
+            alert('연결 실패: ' + error);
+        });
+    }
+
+    function disconnect() {
+        if (isModalOpen) {
+            closeModal();
+        }
+
+        if (stompClient !== null) {
+            stompClient.disconnect();
+            log('🔌 WebSocket 연결 해제');
+        }
+        updateConnectionStatus(false);
+        stopHeartbeat();
+        currentStudyId = null;
+        messageMap.clear();
+    }
+
+    function openModal() {
+        if (!stompClient || !stompClient.connected) {
+            alert('먼저 WebSocket에 연결해주세요');
+            return;
+        }
+
+        log('📂 모달 열기 요청...');
+        stompClient.send(`/app/studies/${currentStudyId}/modal/open`, {}, JSON.stringify({}));
+        updateModalStatus(true);
+        updateUnreadCount(0); // 모달 열면 안읽은 메시지 0으로 초기화
+        startHeartbeat();
+        log('✅ 모달 열림 + Redis 저장 + Heartbeat 시작 + 안읽은 메시지 초기화', true);
+    }
+
+    function closeModal() {
+        if (!stompClient || !stompClient.connected) {
+            alert('먼저 WebSocket에 연결해주세요');
+            return;
+        }
+
+        log('📁 모달 닫기 요청...');
+        stompClient.send(`/app/studies/${currentStudyId}/modal/close`, {}, JSON.stringify({}));
+        updateModalStatus(false);
+        stopHeartbeat();
+        log('✅ 모달 닫힘 + Redis 삭제', true);
+    }
+
+    function sendMessage() {
+        const messageInput = document.getElementById('messageInput');
+        const content = messageInput.value.trim();
+
+        if (!content) {
+            alert('메시지를 입력해주세요');
+            return;
+        }
+
+        if (!stompClient || !stompClient.connected) {
+            alert('먼저 WebSocket에 연결해주세요');
+            return;
+        }
+
+        const message = {
+            content: content
+        };
+
+        log(`📤 메시지 전송: ${content}`);
+        stompClient.send(`/app/studies/${currentStudyId}/chats`, {}, JSON.stringify(message));
+        messageInput.value = '';
+    }
+
+    function displayMessage(message) {
+        const chatMessages = document.getElementById('chatMessages');
+        const messageDiv = document.createElement('div');
+        messageDiv.className = 'message';
+        messageDiv.dataset.messageId = message.messageId;
+
+        const timestamp = new Date(message.createdAt).toLocaleString();
+        
+        // 안 읽은 멤버 수 표시
+        const unreadBadge = message.unreadMemberCount > 0 
+            ? `<span class="unread-badge" data-message-id="${message.messageId}">${message.unreadMemberCount}명 안 읽음</span>`
+            : '';
+
+        messageDiv.innerHTML = `
+            <div class="message-header">
+                <div>
+                    <strong>${message.senderName}</strong> - ${timestamp}
+                </div>
+                ${unreadBadge}
+            </div>
+            <div class="message-content">${escapeHtml(message.content)}</div>
+        `;
+
+        chatMessages.appendChild(messageDiv);
+        chatMessages.scrollTop = chatMessages.scrollHeight;
+        
+        // Map에 저장
+        messageMap.set(message.messageId, messageDiv);
+    }
+
+    function updateUnreadCountForMessagesAfter(previousLastReadMessageId) {
+        // previousLastReadMessageId 초과(>) 메시지만 unreadCount를 -1
+        messageMap.forEach((messageDiv, messageId) => {
+            if (messageId > previousLastReadMessageId) {
+                const badge = messageDiv.querySelector('.unread-badge');
+                if (badge) {
+                    const currentCount = parseInt(badge.textContent);
+                    const newCount = Math.max(0, currentCount - 1);
+                    
+                    if (newCount === 0) {
+                        // 0이 되면 배지 제거
+                        badge.remove();
+                    } else {
+                        badge.textContent = `${newCount}명 안 읽음`;
+                    }
+                }
             }
         });
-    </script>
+    }
+
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    async function loadChatHistory() {
+        const authToken = document.getElementById('authToken').value;
+        const studyId = document.getElementById('studyId').value;
+
+        if (!authToken || !studyId) {
+            alert('스터디 ID와 JWT 토큰을 입력해주세요');
+            return;
+        }
+
+        try {
+            log('📋 채팅 기록 불러오는 중...');
+
+            const response = await fetch(`/api/studies/${studyId}/chats?size=50`, {
+                headers: {
+                    'Authorization': `Bearer ${authToken}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (response.ok) {
+                const data = await response.json();
+                log(`✅ 채팅 기록 ${data.messages.length}개 불러옴 (안 읽은 멤버 수 포함)`);
+
+                document.getElementById('chatMessages').innerHTML = '';
+                messageMap.clear();
+
+                data.messages.reverse().forEach(message => {
+                    displayMessage(message);
+                });
+
+            } else {
+                const errorText = await response.text();
+                log(`❌ 채팅 기록 불러오기 실패: ${response.status}`, true);
+                alert(`채팅 기록 불러오기 실패: ${response.status}`);
+            }
+        } catch (error) {
+            log('❌ 채팅 기록 불러오기 에러: ' + error, true);
+            alert('채팅 기록 불러오기 에러: ' + error.message);
+        }
+    }
+
+    // Enter 키로 메시지 전송
+    document.getElementById('messageInput').addEventListener('keypress', function(e) {
+        if (e.key === 'Enter') {
+            sendMessage();
+        }
+    });
+
+    // 페이지 로드 시
+    window.onload = function() {
+        log('🌊 Pado 채팅 테스트 페이지 로드됨 (Redis 모달 관리 + 안 읽은 멤버 수)');
+        log('📝 사용 전에 JWT 토큰과 스터디 ID를 입력하세요');
+        log('💡 모달이 닫힌 상태에서 메시지가 오면 안읽은 메시지 수가 자동으로 표시됩니다!');
+        log('✨ 각 메시지 옆에 안 읽은 멤버 수가 실시간으로 표시됩니다!');
+    };
+
+    // 페이지 종료 시 연결 해제
+    window.addEventListener('beforeunload', function() {
+        if (isModalOpen) {
+            closeModal();
+        }
+        if (stompClient !== null) {
+            stompClient.disconnect();
+        }
+        stopHeartbeat();
+    });
+</script>
 </body>
 </html>

--- a/src/test/java/com/pado/domain/study/service/StudyServiceImplTest.java
+++ b/src/test/java/com/pado/domain/study/service/StudyServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.pado.domain.study.service;
 
+import com.pado.domain.chat.repository.ChatMessageRepository;
+import com.pado.domain.chat.repository.LastReadMessageRepository;
 import com.pado.domain.shared.entity.Category;
 import com.pado.domain.shared.entity.Region;
 import com.pado.domain.study.dto.request.StudyCreateRequestDto;
@@ -48,6 +50,13 @@ class StudyServiceImplTest {
     @Mock
     private StudyMemberRepository studyMemberRepository;
 
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    // LastReadMessageRepository도 사용되므로 함께 추가해주는 것이 좋습니다.
+    @Mock
+    private LastReadMessageRepository lastReadMessageRepository;
+
     private static final int MAX_PAGE_SIZE = 50;
 
     @Test
@@ -65,6 +74,20 @@ class StudyServiceImplTest {
                 List.of("열심히 하실 분만"),
                 "image_url"
         );
+
+        Study dummySavedStudy = Study.builder()
+                .id(1L) // ID 설정
+                .leader(user)
+                .title(dto.title())
+                .description(dto.description())
+                .detailDescription(dto.detail_description())
+                .studyTime(dto.study_time())
+                .region(dto.region())
+                .maxMembers(dto.max_members())
+                .fileKey(dto.file_key())
+                .build();
+
+        when(studyRepository.save(any(Study.class))).thenReturn(dummySavedStudy);
 
         // when
         studyService.createStudy(user, dto);


### PR DESCRIPTION
## ✨ 요약

카카오톡처럼 채팅방을 읽지 않을 때 안읽은 메세지 수를 출력하는 기능과 채팅방 안에서 메세지 당 읽지 않은 멤버 수를 알려주는 기능을 추가했습니다.

## 🔗 작업 내용
- sockJS 적용
- 채팅방 모달을 켰는지, 껐는지 확인하는 로직 추가
- 스터디 유저가 가장 마지막으로 읽은 메세지 아이디 저장하는 로직 추가
- 채팅방을 읽지 않을 때 안읽은 메세지 수를 출력하는 기능 구현
- 채팅방 안에서 메세지 당 읽지 않은 멤버 수를 알려주는 기능 구현

## 💻 상세 구현 내용

- 프론트와 웹소켓 전송 방식을 통일하기 위해 sockJS를 추가했습니다.
- 현재 채팅방을 읽지 않는 멤버를 찾기 위해 모달을 킬 때, 모달을 끌 때, 모달을 계속 사용할 시 리프레쉬할 때 SEND하는 로직을 추가했습니다.
  - 모달을 키고 있지 않은 사람들에게만 안읽은 메세지 수를 전송할 때 사용됩니다.
  - 모달을 키면 redis에 스터디ID:유저ID를 저장하며 TTL은 5분으로 설정했습니다.
  - 모달을 끄면 해당 데이터를 삭제합니다.
  - 모달을 계속 사용 시 TTL 갱신을 해줘야 하며, 이는 프론트에서 4분마다 SEND를 통해 갱신하도록 구현되어 있습니다.
 - 채팅방 이용 중이 아니면 채팅이 올 때마다 자신이 읽지 않은 메세지 수를 사용자 개인 큐로 전송받습니다.
 - 채팅방 사용 시 메세지마다 읽지 않은 멤버 수를 보여주도록 구현했습니다.
   - 처음 채팅방에 들어와 채팅 목록을 불러오면 메세지 정보들과 함께 안읽은 멤버 수도 전송합니다.
   - 채팅을 보내면 보낸 메세지 정보와 함께 안읽은 멤버 수를 전송합니다.
   - 채팅방 사용 중에 누군가가 채팅방에 들어오면 방금 들어온 멤버가 가장 마지막에 읽었던 메세지 아이디를 전송합니다. 이를 통해 프론트에서는 전송받은 메세지 아이디보다 큰 메세지들의 안읽은 멤버 수에 -1 계산을 하는 방식으로 할 예정입니다.

## 🔗 참고 사항

예상보다 구현할 때 고려해야 할 점들이 많아서 오래 해당 기능을 구현하는 데에 시간을 오래 썼습니다.
원래 구현할 예정이었던 일정, 공지 생성 시 채팅방에 알려주는 기능과 좋아요/싫어요 기능은 다음주에 마저 구현하겠습니다. 
## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #108 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)