### PR TITLE
Feat/#113 스터디 관리 기능 + api 앤드포인트 경로 이관

### DIFF
--- a/src/main/java/com/pado/domain/study/controller/StudyController.java
+++ b/src/main/java/com/pado/domain/study/controller/StudyController.java
@@ -6,6 +6,7 @@ import com.pado.domain.study.dto.response.MyStudyResponseDto;
 import com.pado.domain.study.dto.response.StudyDetailResponseDto;
 import com.pado.domain.study.dto.response.StudyListResponseDto;
 import com.pado.domain.shared.entity.Region;
+import com.pado.domain.study.service.StudyMemberService;
 import com.pado.domain.study.service.StudyService;
 import com.pado.domain.user.entity.User;
 import com.pado.global.auth.annotation.CurrentUser;
@@ -34,6 +35,7 @@ import java.util.List;
 public class StudyController {
 
     private final StudyService studyService;
+    private final StudyMemberService studyMemberService;
 
     @Operation(summary = "스터디 생성", description = "새로운 스터디를 생성 (스터디 이름, 한 줄 소개, 스터디 설명, 카테고리, 제한 인원, 이미지)")
     @ApiResponse(
@@ -136,6 +138,20 @@ public class StudyController {
         @Parameter(hidden = true) @CurrentUser User user,
         @PathVariable("study_id") Long studyId) {
         studyService.leaveStudy(user, studyId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "스터디 신청 취소", description = "사용자가 승인 대기 중인 스터디 신청을 스스로 취소합니다.")
+    @ApiResponse(responseCode = "204", description = "신청 취소 성공")
+    @Parameters({
+        @Parameter(name = "study_id", description = "신청을 취소할 스터디의 ID", required = true, example = "1")
+    })
+    @DeleteMapping("/{study_id}/applications/me")
+    public ResponseEntity<Void> cancelApplication(
+        @Parameter(hidden = true) @CurrentUser User user,
+        @PathVariable("study_id") Long studyId
+    ) {
+        studyMemberService.cancelApplication(user, studyId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/pado/domain/study/controller/StudyController.java
+++ b/src/main/java/com/pado/domain/study/controller/StudyController.java
@@ -111,10 +111,11 @@ public class StudyController {
     })
     @PatchMapping("/{study_id}")
     public ResponseEntity<Void> updateStudy(
+        @Parameter(hidden = true) @CurrentUser User user,
         @PathVariable("study_id") Long studyId,
         @Valid @RequestBody StudyCreateRequestDto request
     ) {
-        // TODO: 스터디 정보 수정 기능 구현
+        studyService.updateStudy(user, studyId, request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/pado/domain/study/controller/StudyController.java
+++ b/src/main/java/com/pado/domain/study/controller/StudyController.java
@@ -49,16 +49,6 @@ public class StudyController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @Operation(summary = "내 스터디 목록 조회", description = "현재 로그인한 사용자가 참여하고 있는 스터디 목록을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "조회 성공")
-    @GetMapping("/me")
-    public ResponseEntity<List<MyStudyResponseDto>> getMyStudies(
-        @Parameter(hidden = true) @CurrentUser User user
-    ) {
-        List<MyStudyResponseDto> myStudies = studyService.findMyStudies(user.getId());
-        return ResponseEntity.ok(myStudies);
-    }
-
     @SecurityRequirements({})
     @Operation(summary = "스터디 목록 조회 및 검색",
         description = """

--- a/src/main/java/com/pado/domain/study/controller/StudyController.java
+++ b/src/main/java/com/pado/domain/study/controller/StudyController.java
@@ -37,12 +37,12 @@ public class StudyController {
 
     @Operation(summary = "스터디 생성", description = "새로운 스터디를 생성 (스터디 이름, 한 줄 소개, 스터디 설명, 카테고리, 제한 인원, 이미지)")
     @ApiResponse(
-            responseCode = "201", description = "스터디 생성 성공"
+        responseCode = "201", description = "스터디 생성 성공"
     )
     @PostMapping
     public ResponseEntity<Void> createStudy(
-            @Parameter(hidden = true) @CurrentUser User user,
-            @Valid @RequestBody StudyCreateRequestDto request) {
+        @Parameter(hidden = true) @CurrentUser User user,
+        @Valid @RequestBody StudyCreateRequestDto request) {
         studyService.createStudy(user, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -51,7 +51,7 @@ public class StudyController {
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping("/me")
     public ResponseEntity<List<MyStudyResponseDto>> getMyStudies(
-            @Parameter(hidden = true) @CurrentUser User user
+        @Parameter(hidden = true) @CurrentUser User user
     ) {
         List<MyStudyResponseDto> myStudies = studyService.findMyStudies(user.getId());
         return ResponseEntity.ok(myStudies);
@@ -59,30 +59,31 @@ public class StudyController {
 
     @SecurityRequirements({})
     @Operation(summary = "스터디 목록 조회 및 검색",
-            description = """
-               검색어 및 필터링 조건을 통해 '모집 중'인 스터디 목록을 조회합니다.
-               - **로그인 사용자**: 필터 적용 여부 + 사용자의 관심사/지역/최신성/검색어 등을 종합한 추천 점수 순으로 정렬됩니다.
-               - **비로그인 사용자**: 최신순으로 정렬됩니다.
-               """)
+        description = """
+            검색어 및 필터링 조건을 통해 '모집 중'인 스터디 목록을 조회합니다.
+            - **로그인 사용자**: 필터 적용 여부 + 사용자의 관심사/지역/최신성/검색어 등을 종합한 추천 점수 순으로 정렬됩니다.
+            - **비로그인 사용자**: 최신순으로 정렬됩니다.
+            """)
     @ApiResponse(responseCode = "200", description = "스터디 목록 조회 성공",
-            content = @Content(schema = @Schema(implementation = StudyListResponseDto.class)))
+        content = @Content(schema = @Schema(implementation = StudyListResponseDto.class)))
     @Parameters({
-            @Parameter(name = "keyword", description = "검색할 키워드 (제목 또는 한 줄 소개, 선택 사항)", example = "스프링"),
-            @Parameter(name = "interests", description = "필터링할 카테고리(관심 분야) 목록. 여러 개 가능.", example = "프로그래밍,취업"),
-            @Parameter(name = "locations", description = "필터링할 지역 목록. 여러 개 가능.", example = "서울,경기"),
-            @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", required = true, example = "0"),
-            @Parameter(name = "size", description = "페이지 당 사이즈 (기본값 10)", example = "10")
+        @Parameter(name = "keyword", description = "검색할 키워드 (제목 또는 한 줄 소개, 선택 사항)", example = "스프링"),
+        @Parameter(name = "interests", description = "필터링할 카테고리(관심 분야) 목록. 여러 개 가능.", example = "프로그래밍,취업"),
+        @Parameter(name = "locations", description = "필터링할 지역 목록. 여러 개 가능.", example = "서울,경기"),
+        @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", required = true, example = "0"),
+        @Parameter(name = "size", description = "페이지 당 사이즈 (기본값 10)", example = "10")
     })
     @GetMapping
     public ResponseEntity<StudyListResponseDto> findStudies(
-            @Parameter(hidden = true) @CurrentUser User user,
-            @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) List<Category> interests,
-            @RequestParam(required = false) List<Region> locations,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+        @Parameter(hidden = true) @CurrentUser User user,
+        @RequestParam(required = false) String keyword,
+        @RequestParam(required = false) List<Category> interests,
+        @RequestParam(required = false) List<Region> locations,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
     ) {
-        StudyListResponseDto response = studyService.findStudies(user, keyword, interests, locations, page, size);
+        StudyListResponseDto response = studyService.findStudies(user, keyword, interests,
+            locations, page, size);
         return ResponseEntity.ok(response);
     }
 
@@ -90,15 +91,15 @@ public class StudyController {
     @Api404StudyNotFoundError
     @Operation(summary = "스터디 상세 정보 조회", description = "지정된 ID를 가진 스터디의 상세 정보를 조회합니다.")
     @ApiResponse(
-            responseCode = "200", description = "스터디 상세 정보 조회 성공",
-            content = @Content(schema = @Schema(implementation = StudyDetailResponseDto.class))
+        responseCode = "200", description = "스터디 상세 정보 조회 성공",
+        content = @Content(schema = @Schema(implementation = StudyDetailResponseDto.class))
     )
     @Parameters({
-            @Parameter(name = "study_id", description = "조회할 스터디의 ID", required = true, example = "1")
+        @Parameter(name = "study_id", description = "조회할 스터디의 ID", required = true, example = "1")
     })
     @GetMapping("/{study_id}")
     public ResponseEntity<StudyDetailResponseDto> getStudyDetail(
-            @PathVariable("study_id") Long studyId
+        @PathVariable("study_id") Long studyId
     ) {
         StudyDetailResponseDto responseDto = studyService.getStudyDetail(studyId);
         return ResponseEntity.ok(responseDto);
@@ -107,21 +108,34 @@ public class StudyController {
     @Api403ForbiddenStudyLeaderOnlyError
     @Api404StudyNotFoundError
     @Operation(
-            summary = "스터디 정보 수정",
-            description = "지정된 스터디의 정보를 수정합니다. (스터디 리더만 가능)"
+        summary = "스터디 정보 수정",
+        description = "지정된 스터디의 정보를 수정합니다. (스터디 리더만 가능)"
     )
     @ApiResponse(
-            responseCode = "200", description = "스터디 정보 수정 성공"
+        responseCode = "200", description = "스터디 정보 수정 성공"
     )
     @Parameters({
-            @Parameter(name = "study_id", description = "수정할 스터디의 ID", required = true, example = "1")
+        @Parameter(name = "study_id", description = "수정할 스터디의 ID", required = true, example = "1")
     })
     @PatchMapping("/{study_id}")
     public ResponseEntity<Void> updateStudy(
-            @PathVariable("study_id") Long studyId,
-            @Valid @RequestBody StudyCreateRequestDto request
+        @PathVariable("study_id") Long studyId,
+        @Valid @RequestBody StudyCreateRequestDto request
     ) {
         // TODO: 스터디 정보 수정 기능 구현
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "스터디 자진 탈퇴", description = "스터디 멤버가 스스로 스터디를 탈퇴합니다.")
+    @ApiResponse(responseCode = "204", description = "스터디 탈퇴 성공")
+    @Parameters({
+        @Parameter(name = "study_id", description = "탈퇴할 스터디의 ID", required = true, example = "1")
+    })
+    @DeleteMapping("/{study_id}/membership")
+    public ResponseEntity<Void> leaveStudy(
+        @Parameter(hidden = true) @CurrentUser User user,
+        @PathVariable("study_id") Long studyId) {
+        studyService.leaveStudy(user, studyId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/pado/domain/study/controller/StudyMemberController.java
+++ b/src/main/java/com/pado/domain/study/controller/StudyMemberController.java
@@ -3,15 +3,10 @@ package com.pado.domain.study.controller;
 import com.pado.domain.study.dto.request.StudyApplicationStatusChangeRequestDto;
 import com.pado.domain.study.dto.request.StudyApplyRequestDto;
 import com.pado.domain.study.dto.request.StudyMemberRoleChangeRequestDto;
-import com.pado.domain.study.dto.response.StudyMemberDetailDto;
 import com.pado.domain.study.dto.response.StudyMemberListResponseDto;
-import com.pado.domain.study.dto.response.UserDetailDto;
 import com.pado.domain.study.service.StudyMemberService;
-import com.pado.domain.study.service.StudyService;
-import com.pado.domain.user.entity.Gender;
 import com.pado.domain.user.entity.User;
 import com.pado.global.auth.annotation.CurrentUser;
-import com.pado.global.exception.dto.ErrorResponseDto;
 import com.pado.global.swagger.annotation.study.Api403ForbiddenStudyLeaderOnlyError;
 import com.pado.global.swagger.annotation.study.Api404StudyNotFoundError;
 import com.pado.global.swagger.annotation.study.Api404StudyOrMemberNotFoundError;
@@ -19,7 +14,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -29,8 +23,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Tag(name = "05. Study Member", description = "스터디원 관리 및 신청 관련 API")
 @RestController
@@ -43,16 +35,16 @@ public class StudyMemberController {
     @Api404StudyNotFoundError
     @Operation(summary = "스터디 참여 신청", description = "사용자가 스터디에 참여 신청을 보냅니다.")
     @ApiResponse(
-            responseCode = "201", description = "스터디 참여 신청 성공"
+        responseCode = "201", description = "스터디 참여 신청 성공"
     )
     @Parameters({
-            @Parameter(name = "study_id", description = "참여 신청할 스터디의 ID", required = true, example = "1")
+        @Parameter(name = "study_id", description = "참여 신청할 스터디의 ID", required = true, example = "1")
     })
     @PostMapping("/apply")
     public ResponseEntity<Void> applyToStudy(
-            @Parameter(hidden = true) @CurrentUser User user,
-            @PathVariable("study_id") Long studyId,
-            @Valid @RequestBody StudyApplyRequestDto request
+        @Parameter(hidden = true) @CurrentUser User user,
+        @PathVariable("study_id") Long studyId,
+        @Valid @RequestBody StudyApplyRequestDto request
     ) {
         studyMemberService.applyToStudy(user, studyId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -61,70 +53,66 @@ public class StudyMemberController {
     @Api403ForbiddenStudyLeaderOnlyError
     @Api404StudyNotFoundError
     @Operation(
-            summary = "스터디원 목록 조회",
-            description = "스터디원 목록을 조회합니다. (스터디 리더만 접근 가능)"
+        summary = "스터디원 목록 조회",
+        description = "스터디원 목록을 조회합니다. (스터디 리더만 접근 가능)"
     )
     @ApiResponse(
-            responseCode = "200", description = "스터디원 목록 조회 성공",
-            content = @Content(schema = @Schema(implementation = StudyMemberListResponseDto.class))
+        responseCode = "200", description = "스터디원 목록 조회 성공",
+        content = @Content(schema = @Schema(implementation = StudyMemberListResponseDto.class))
     )
     @Parameters({
-            @Parameter(name = "study_id", description = "조회할 스터디의 ID", required = true, example = "1")
+        @Parameter(name = "study_id", description = "조회할 스터디의 ID", required = true, example = "1")
     })
-    @GetMapping("/member")
+    @GetMapping("/members")
     public ResponseEntity<StudyMemberListResponseDto> getStudyMembers(
-            @PathVariable("study_id") Long studyId
+        @Parameter(hidden = true) @CurrentUser User user,
+        @PathVariable("study_id") Long studyId
     ) {
-        // TODO: 스터디원 목록 조회 로직 구현
-        List<StudyMemberDetailDto> members = List.of(
-                new StudyMemberDetailDto("리더유저", "Leader", null, new UserDetailDto("https://pado-image.com/user/1", "Women", List.of("프로그래밍", "취업"), "서울")),
-                new StudyMemberDetailDto("참여자1", "Member", null, new UserDetailDto("https://pado-image.com/user/2", "Men", List.of("어학", "고시/공무원"), "경기")),
-                new StudyMemberDetailDto("신청자1", "Pending", "안녕하세요. 열심히 참여하고 싶습니다!", new UserDetailDto("https://pado-image.com/user/3", "Men", List.of("취미/교양"), "부산"))
-        );
-        return ResponseEntity.ok(new StudyMemberListResponseDto(members));
+        return ResponseEntity.ok(studyMemberService.getStudyMembers(user, studyId));
     }
 
     @Api403ForbiddenStudyLeaderOnlyError
     @Api404StudyOrMemberNotFoundError
     @Operation(
-            summary = "특정 스터디원 탈퇴/신청 거부",
-            description = "특정 스터디원을 탈퇴시키거나, 스터디 신청을 거부합니다. (스터디 리더만 가능)"
+        summary = "특정 스터디원 탈퇴/신청 거부",
+        description = "특정 스터디원을 탈퇴시키거나, 스터디 신청을 거부합니다. (스터디 리더만 가능)"
     )
     @ApiResponse(
-            responseCode = "204", description = "탈퇴/거부 성공"
+        responseCode = "204", description = "탈퇴/거부 성공"
     )
     @Parameters({
-            @Parameter(name = "study_id", description = "스터디 ID", required = true, example = "1"),
-            @Parameter(name = "member_id", description = "탈퇴시키거나 거부할 스터디원의 ID", required = true, example = "2")
+        @Parameter(name = "study_id", description = "스터디 ID", required = true, example = "1"),
+        @Parameter(name = "member_id", description = "탈퇴시키거나 거부할 스터디원의 ID", required = true, example = "2")
     })
-    @DeleteMapping("/member/{member_id}")
+    @DeleteMapping("/members/{member_id}")
     public ResponseEntity<Void> kickMember(
-            @PathVariable("study_id") Long studyId,
-            @PathVariable("member_id") Long memberId
+        @Parameter(hidden = true) @CurrentUser User user,
+        @PathVariable("study_id") Long studyId,
+        @PathVariable("member_id") Long memberId
     ) {
-        // TODO: 특정 스터디원 탈퇴/신청 거부 로직 구현
+        studyMemberService.kickMember(user, studyId, memberId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @Api403ForbiddenStudyLeaderOnlyError
     @Api404StudyOrMemberNotFoundError
     @Operation(
-            summary = "스터디원 상태 변경",
-            description = "특정 스터디원의 역할을 변경합니다. (스터디 리더만 가능)"
+        summary = "스터디원 상태 변경",
+        description = "특정 스터디원의 역할을 변경합니다. (스터디 리더만 가능)"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "상태 변경/수락 성공"),
-            @ApiResponse(responseCode = "409", description = "유효하지 않은 상태 변경")
+        @ApiResponse(responseCode = "200", description = "상태 변경/수락 성공"),
+        @ApiResponse(responseCode = "409", description = "유효하지 않은 상태 변경")
     })
     @Parameters({
-            @Parameter(name = "study_id", description = "스터디 ID", required = true, example = "1"),
-            @Parameter(name = "member_id", description = "역할을 변경할 스터디원의 ID", required = true, example = "2")
+        @Parameter(name = "study_id", description = "스터디 ID", required = true, example = "1"),
+        @Parameter(name = "member_id", description = "역할을 변경할 스터디원의 ID", required = true, example = "2")
     })
     @PatchMapping("/member/{member_id}")
     public ResponseEntity<Void> updateMemberRole(
-            @PathVariable("study_id") Long studyId,
-            @PathVariable("member_id") Long memberId,
-            @Valid @RequestBody StudyMemberRoleChangeRequestDto request
+        @PathVariable("study_id") Long studyId,
+        @PathVariable("member_id") Long memberId,
+        @Valid @RequestBody StudyMemberRoleChangeRequestDto request
     ) {
         // TODO: 스터디원 상태 변경
         return ResponseEntity.ok().build();
@@ -133,23 +121,23 @@ public class StudyMemberController {
     @Api403ForbiddenStudyLeaderOnlyError
     @Api404StudyOrMemberNotFoundError
     @Operation(
-            summary = "스터디원 상태 변경",
-            description = "특정 스터디원의 역할을 변경합니다. (스터디 리더만 가능)"
+        summary = "스터디원 상태 변경",
+        description = "특정 스터디원의 역할을 변경합니다. (스터디 리더만 가능)"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "상태 변경/수락 성공"),
-            @ApiResponse(responseCode = "409", description = "유효하지 않은 상태 변경")
+        @ApiResponse(responseCode = "200", description = "상태 변경/수락 성공"),
+        @ApiResponse(responseCode = "409", description = "유효하지 않은 상태 변경")
     })
     @Parameters({
-            @Parameter(name = "study_id", description = "스터디 ID", required = true, example = "1"),
-            @Parameter(name = "member_id", description = "역할을 변경할 스터디원의 ID", required = true, example = "2")
+        @Parameter(name = "study_id", description = "스터디 ID", required = true, example = "1"),
+        @Parameter(name = "member_id", description = "역할을 변경할 스터디원의 ID", required = true, example = "2")
     })
     @PatchMapping("/applications/{application_id}")
     public ResponseEntity<Void> updateMemberApplicationStatus(
-            @Parameter(hidden = true) @CurrentUser User user,
-            @PathVariable("study_id") Long studyId,
-            @PathVariable("application_id") Long applicationId,
-            @Valid @RequestBody StudyApplicationStatusChangeRequestDto request
+        @Parameter(hidden = true) @CurrentUser User user,
+        @PathVariable("study_id") Long studyId,
+        @PathVariable("application_id") Long applicationId,
+        @Valid @RequestBody StudyApplicationStatusChangeRequestDto request
     ) {
         studyMemberService.updateApplicationStatus(user, studyId, applicationId, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/pado/domain/study/controller/StudyMemberController.java
+++ b/src/main/java/com/pado/domain/study/controller/StudyMemberController.java
@@ -131,13 +131,13 @@ public class StudyMemberController {
     })
     @Parameters({
         @Parameter(name = "study_id", description = "스터디 ID", required = true, example = "1"),
-        @Parameter(name = "application_id", description = "처리할 신청서의 ID", required = true, example = "1")
+        @Parameter(name = "app_id", description = "처리할 신청서의 ID", required = true, example = "1")
     })
-    @PatchMapping("/applications/{application_id}")
+    @PatchMapping("/applications/{app_id}")
     public ResponseEntity<Void> updateMemberApplicationStatus(
         @Parameter(hidden = true) @CurrentUser User user,
         @PathVariable("study_id") Long studyId,
-        @PathVariable("application_id") Long applicationId,
+        @PathVariable("app_id") Long applicationId,
         @Valid @RequestBody StudyApplicationStatusChangeRequestDto request
     ) {
         studyMemberService.updateApplicationStatus(user, studyId, applicationId, request);

--- a/src/main/java/com/pado/domain/study/dto/request/StudyLeaderDelegateRequestDto.java
+++ b/src/main/java/com/pado/domain/study/dto/request/StudyLeaderDelegateRequestDto.java
@@ -1,0 +1,13 @@
+package com.pado.domain.study.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "스터디 리더 위임 요청 DTO")
+public record StudyLeaderDelegateRequestDto(
+    @Schema(description = "새로운 리더로 지정할 스터디 멤버의 ID", example = "2")
+    @NotNull(message = "새로운 리더의 ID는 필수입니다.")
+    Long newLeaderMemberId
+) {
+
+}

--- a/src/main/java/com/pado/domain/study/dto/response/MyApplicationResponseDto.java
+++ b/src/main/java/com/pado/domain/study/dto/response/MyApplicationResponseDto.java
@@ -1,0 +1,25 @@
+package com.pado.domain.study.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "내가 신청한 스터디 정보 응답 DTO")
+@Builder
+public record MyApplicationResponseDto(
+    @Schema(description = "스터디 신청 ID", example = "1")
+    Long applicationId,
+
+    @Schema(description = "스터디 ID", example = "10")
+    Long studyId,
+
+    @Schema(description = "스터디 제목", example = "스프링 스터디")
+    String studyTitle,
+
+    @Schema(description = "신청 상태", example = "PENDING")
+    String status,
+
+    @Schema(description = "신청 시 보낸 메시지", example = "열심히 참여하겠습니다!")
+    String message
+) {
+
+}

--- a/src/main/java/com/pado/domain/study/entity/Study.java
+++ b/src/main/java/com/pado/domain/study/entity/Study.java
@@ -16,54 +16,46 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Table(name = "study", indexes = {
-        @Index(name = "idx_study_status_created_at", columnList = "status, createdAt"),
-        @Index(name = "idx_study_region", columnList = "region")
+    @Index(name = "idx_study_status_created_at", columnList = "status, createdAt"),
+    @Index(name = "idx_study_region", columnList = "region")
 })
 public class Study extends AuditingEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "leader_id", nullable = false)
     private User leader;
-
     @Column(nullable = false, length = 100)
     private String title;
-
     @Column(nullable = false, length = 200)
     private String description;
 
     @Lob
     private String detailDescription;
-
     @Column(length = 100)
     private String studyTime;
 
     @Column(nullable = false)
     private Integer maxMembers;
-
     @Column(length = 500)
     private String fileKey;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
     private Region region;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
     @Builder.Default
     private StudyStatus status = StudyStatus.RECRUITING;
-
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<StudyCondition> conditions = new ArrayList<>();
-
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<StudyCategory> interests = new ArrayList<>();
-
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<StudyMember> studyMembers = new ArrayList<>();
@@ -72,13 +64,13 @@ public class Study extends AuditingEntity {
         this.interests.clear();
         if (categories != null) {
             List<StudyCategory> newInterests = categories.stream()
-                    .map(category -> StudyCategory
-                            .builder()
-                            .study(this)
-                            .category(category)
-                            .build()
-                    )
-                    .toList();
+                .map(category -> StudyCategory
+                    .builder()
+                    .study(this)
+                    .category(category)
+                    .build()
+                )
+                .toList();
             this.interests.addAll(newInterests);
         }
     }
@@ -87,12 +79,13 @@ public class Study extends AuditingEntity {
         this.conditions.clear();
         if (conditionContents != null) {
             List<StudyCondition> newConditions = conditionContents.stream()
-                    .map(content -> StudyCondition.builder()
-                            .study(this)
-                            .content(content)
-                            .build())
-                    .toList();
+                .map(content -> StudyCondition.builder()
+                    .study(this)
+                    .content(content)
+                    .build())
+                .toList();
             this.conditions.addAll(newConditions);
         }
     }
+
 }

--- a/src/main/java/com/pado/domain/study/entity/Study.java
+++ b/src/main/java/com/pado/domain/study/entity/Study.java
@@ -60,6 +60,20 @@ public class Study extends AuditingEntity {
     @Builder.Default
     private List<StudyMember> studyMembers = new ArrayList<>();
 
+    public void update(String title, String description, String detailDescription, Region region,
+        String studyTime, Integer maxMembers, String fileKey, List<Category> interests,
+        List<String> conditions) {
+        this.title = title;
+        this.description = description;
+        this.detailDescription = detailDescription;
+        this.region = region;
+        this.studyTime = studyTime;
+        this.maxMembers = maxMembers;
+        this.fileKey = fileKey;
+        addInterests(interests);
+        addConditions(conditions);
+    }
+
     public void addInterests(List<Category> categories) {
         this.interests.clear();
         if (categories != null) {

--- a/src/main/java/com/pado/domain/study/entity/StudyMember.java
+++ b/src/main/java/com/pado/domain/study/entity/StudyMember.java
@@ -17,19 +17,15 @@ public class StudyMember extends AuditingEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_id", nullable = false)
     private Study study;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
     private StudyMemberRole role;
-
     @Column(length = 500)
     private String message;
 
@@ -37,7 +33,8 @@ public class StudyMember extends AuditingEntity {
     private Integer rankPoint;
 
     @Builder
-    public StudyMember(Study study, User user, StudyMemberRole role, String message, Integer rankPoint) {
+    public StudyMember(Study study, User user, StudyMemberRole role, String message,
+        Integer rankPoint) {
         this.study = study;
         this.user = user;
         this.role = role;
@@ -55,5 +52,9 @@ public class StudyMember extends AuditingEntity {
         if (pointsToSubtract > 0) {
             this.rankPoint = Math.max(0, this.rankPoint - pointsToSubtract);
         }
+    }
+
+    public void updateRole(StudyMemberRole role) {
+        this.role = role;
     }
 }

--- a/src/main/java/com/pado/domain/study/repository/StudyApplicationRepository.java
+++ b/src/main/java/com/pado/domain/study/repository/StudyApplicationRepository.java
@@ -5,7 +5,15 @@ import com.pado.domain.study.entity.StudyApplication;
 import com.pado.domain.study.entity.StudyApplicationStatus;
 import com.pado.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface StudyApplicationRepository extends JpaRepository<StudyApplication, Long> {
+
     boolean existsByStudyAndUserAndStatus(Study study, User user, StudyApplicationStatus status);
+
+    @Query("SELECT sa FROM StudyApplication sa JOIN FETCH sa.user WHERE sa.study = :study")
+    List<StudyApplication> findByStudyWithUser(@Param("study") Study study);
 }

--- a/src/main/java/com/pado/domain/study/repository/StudyApplicationRepository.java
+++ b/src/main/java/com/pado/domain/study/repository/StudyApplicationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StudyApplicationRepository extends JpaRepository<StudyApplication, Long> {
 
@@ -16,4 +17,10 @@ public interface StudyApplicationRepository extends JpaRepository<StudyApplicati
 
     @Query("SELECT sa FROM StudyApplication sa JOIN FETCH sa.user WHERE sa.study = :study")
     List<StudyApplication> findByStudyWithUser(@Param("study") Study study);
+
+    Optional<StudyApplication> findByStudyAndUserAndStatus(Study study, User user,
+        StudyApplicationStatus status);
+
+    @Query("SELECT sa FROM StudyApplication sa JOIN FETCH sa.study WHERE sa.user = :user")
+    List<StudyApplication> findByUserWithStudy(@Param("user") User user);
 }

--- a/src/main/java/com/pado/domain/study/service/StudyMemberService.java
+++ b/src/main/java/com/pado/domain/study/service/StudyMemberService.java
@@ -20,4 +20,6 @@ public interface StudyMemberService {
     StudyMemberListResponseDto getStudyMembers(User user, Long studyId);
 
     void kickMember(User user, Long studyId, Long memberId);
+
+    void delegateLeadership(User user, Long studyId, Long newLeaderMemberId);
 }

--- a/src/main/java/com/pado/domain/study/service/StudyMemberService.java
+++ b/src/main/java/com/pado/domain/study/service/StudyMemberService.java
@@ -2,6 +2,7 @@ package com.pado.domain.study.service;
 
 import com.pado.domain.study.dto.request.StudyApplicationStatusChangeRequestDto;
 import com.pado.domain.study.dto.request.StudyApplyRequestDto;
+import com.pado.domain.study.dto.response.StudyMemberListResponseDto;
 import com.pado.domain.study.entity.Study;
 import com.pado.domain.user.entity.User;
 
@@ -13,5 +14,10 @@ public interface StudyMemberService {
 
     boolean isStudyMember(User user, Long studyId);
 
-    void updateApplicationStatus(User user, Long studyId, Long applicationId, StudyApplicationStatusChangeRequestDto request);
+    void updateApplicationStatus(User user, Long studyId, Long applicationId,
+        StudyApplicationStatusChangeRequestDto request);
+
+    StudyMemberListResponseDto getStudyMembers(User user, Long studyId);
+
+    void kickMember(User user, Long studyId, Long memberId);
 }

--- a/src/main/java/com/pado/domain/study/service/StudyMemberService.java
+++ b/src/main/java/com/pado/domain/study/service/StudyMemberService.java
@@ -22,4 +22,6 @@ public interface StudyMemberService {
     void kickMember(User user, Long studyId, Long memberId);
 
     void delegateLeadership(User user, Long studyId, Long newLeaderMemberId);
+
+    void cancelApplication(User user, Long studyId);
 }

--- a/src/main/java/com/pado/domain/study/service/StudyMemberServiceImpl.java
+++ b/src/main/java/com/pado/domain/study/service/StudyMemberServiceImpl.java
@@ -11,7 +11,6 @@ import com.pado.domain.study.repository.StudyApplicationRepository;
 import com.pado.domain.study.repository.StudyMemberRepository;
 import com.pado.domain.study.repository.StudyRepository;
 import com.pado.domain.user.entity.User;
-import com.pado.domain.user.entity.UserInterest;
 import com.pado.global.exception.common.BusinessException;
 import com.pado.global.exception.common.ErrorCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/pado/domain/study/service/StudyMemberServiceImpl.java
+++ b/src/main/java/com/pado/domain/study/service/StudyMemberServiceImpl.java
@@ -181,6 +181,20 @@ public class StudyMemberServiceImpl implements StudyMemberService {
         newLeaderMember.updateRole(StudyMemberRole.LEADER);
     }
 
+    @Override
+    @Transactional
+    public void cancelApplication(User user, Long studyId) {
+        Study study = studyRepository.findById(studyId)
+            .orElseThrow(StudyNotFoundException::new);
+
+        StudyApplication application = studyApplicationRepository.findByStudyAndUserAndStatus(study,
+                user, StudyApplicationStatus.PENDING)
+            .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_APPLICATION_NOT_FOUND,
+                "대기 중인 스터디 신청이 없습니다."));
+
+        studyApplicationRepository.delete(application);
+    }
+
     private UserDetailDto mapToUserDetailDto(User user) {
         return new UserDetailDto(
             user.getImage_key(),

--- a/src/main/java/com/pado/domain/study/service/StudyService.java
+++ b/src/main/java/com/pado/domain/study/service/StudyService.java
@@ -3,7 +3,6 @@ package com.pado.domain.study.service;
 import com.pado.domain.shared.entity.Category;
 import com.pado.domain.shared.entity.Region;
 import com.pado.domain.study.dto.request.StudyCreateRequestDto;
-import com.pado.domain.study.dto.response.MyStudyResponseDto;
 import com.pado.domain.study.dto.response.StudyDetailResponseDto;
 import com.pado.domain.study.dto.response.StudyListResponseDto;
 import com.pado.domain.user.entity.User;
@@ -20,4 +19,6 @@ public interface StudyService {
     StudyDetailResponseDto getStudyDetail(Long studyId);
 
     void leaveStudy(User user, Long studyId);
+
+    void updateStudy(User user, Long studyId, StudyCreateRequestDto requestDto);
 }

--- a/src/main/java/com/pado/domain/study/service/StudyService.java
+++ b/src/main/java/com/pado/domain/study/service/StudyService.java
@@ -11,8 +11,15 @@ import com.pado.domain.user.entity.User;
 import java.util.List;
 
 public interface StudyService {
+
     void createStudy(User user, StudyCreateRequestDto requestDto);
+
     List<MyStudyResponseDto> findMyStudies(Long userId);
-    StudyListResponseDto findStudies(User user, String keyword, List<Category> categories, List<Region> regions, int page, int size);
+
+    StudyListResponseDto findStudies(User user, String keyword, List<Category> categories,
+        List<Region> regions, int page, int size);
+
     StudyDetailResponseDto getStudyDetail(Long studyId);
+
+    void leaveStudy(User user, Long studyId);
 }

--- a/src/main/java/com/pado/domain/study/service/StudyService.java
+++ b/src/main/java/com/pado/domain/study/service/StudyService.java
@@ -14,8 +14,6 @@ public interface StudyService {
 
     void createStudy(User user, StudyCreateRequestDto requestDto);
 
-    List<MyStudyResponseDto> findMyStudies(Long userId);
-
     StudyListResponseDto findStudies(User user, String keyword, List<Category> categories,
         List<Region> regions, int page, int size);
 

--- a/src/main/java/com/pado/domain/study/service/StudyServiceImpl.java
+++ b/src/main/java/com/pado/domain/study/service/StudyServiceImpl.java
@@ -58,16 +58,6 @@ public class StudyServiceImpl implements StudyService {
         studyMemberRepository.save(leaderMember);
     }
 
-    public List<MyStudyResponseDto> findMyStudies(Long userId) {
-        List<Study> studies = studyRepository.findByUserId(userId);
-        return studies.stream()
-            .map(study -> new MyStudyResponseDto(
-                study.getId(),
-                study.getTitle()
-            ))
-            .collect(Collectors.toList());
-    }
-
     @Override
     @Transactional(readOnly = true)
     public StudyListResponseDto findStudies(User user, String keyword, List<Category> categories,

--- a/src/main/java/com/pado/domain/study/service/StudyServiceImpl.java
+++ b/src/main/java/com/pado/domain/study/service/StudyServiceImpl.java
@@ -12,6 +12,8 @@ import com.pado.domain.study.exception.StudyNotFoundException;
 import com.pado.domain.study.repository.StudyMemberRepository;
 import com.pado.domain.study.repository.StudyRepository;
 import com.pado.domain.user.entity.User;
+import com.pado.global.exception.common.BusinessException;
+import com.pado.global.exception.common.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -35,55 +37,53 @@ public class StudyServiceImpl implements StudyService {
     @Transactional
     public void createStudy(User user, StudyCreateRequestDto requestDto) {
         Study newStudy = Study.builder()
-                .leader(user)
-                .title(requestDto.title())
-                .description(requestDto.description())
-                .detailDescription(requestDto.detail_description())
-                .studyTime(requestDto.study_time())
-                .region(requestDto.region())
-                .maxMembers(requestDto.max_members())
-                .fileKey(requestDto.file_key())
-                .build();
-
+            .leader(user)
+            .title(requestDto.title())
+            .description(requestDto.description())
+            .detailDescription(requestDto.detail_description())
+            .studyTime(requestDto.study_time())
+            .region(requestDto.region())
+            .maxMembers(requestDto.max_members())
+            .fileKey(requestDto.file_key())
+            .build();
         newStudy.addInterests(requestDto.interests());
         newStudy.addConditions(requestDto.conditions());
 
         StudyMember leaderMember = StudyMember.builder()
-                .study(newStudy)
-                .user(user)
-                .role(StudyMemberRole.LEADER)
-                .build();
-
+            .study(newStudy)
+            .user(user)
+            .role(StudyMemberRole.LEADER)
+            .build();
         studyRepository.save(newStudy);
         studyMemberRepository.save(leaderMember);
     }
 
     public List<MyStudyResponseDto> findMyStudies(Long userId) {
         List<Study> studies = studyRepository.findByUserId(userId);
-
         return studies.stream()
-                .map(study -> new MyStudyResponseDto(
-                        study.getId(),
-                        study.getTitle()
-                ))
-                .collect(Collectors.toList());
+            .map(study -> new MyStudyResponseDto(
+                study.getId(),
+                study.getTitle()
+            ))
+            .collect(Collectors.toList());
     }
 
     @Override
     @Transactional(readOnly = true)
-    public StudyListResponseDto findStudies(User user, String keyword, List<Category> categories, List<Region> regions, int page, int size) {
+    public StudyListResponseDto findStudies(User user, String keyword, List<Category> categories,
+        List<Region> regions, int page, int size) {
         Pageable pageable = createPageable(page, size);
-        Slice<Study> studySlice = studyRepository.findStudiesByFilter(user, keyword, categories, regions, pageable);
+        Slice<Study> studySlice = studyRepository.findStudiesByFilter(user, keyword, categories,
+            regions, pageable);
 
         List<StudySimpleResponseDto> studyDtos = studySlice.getContent().stream()
-                .map(StudySimpleResponseDto::from)
-                .collect(Collectors.toList());
-
+            .map(StudySimpleResponseDto::from)
+            .collect(Collectors.toList());
         return new StudyListResponseDto(
-                studyDtos,
-                pageable.getPageNumber(),
-                pageable.getPageSize(),
-                studySlice.hasNext()
+            studyDtos,
+            pageable.getPageNumber(),
+            pageable.getPageSize(),
+            studySlice.hasNext()
         );
     }
 
@@ -91,30 +91,43 @@ public class StudyServiceImpl implements StudyService {
     @Transactional(readOnly = true)
     public StudyDetailResponseDto getStudyDetail(Long studyId) {
         Study study = studyRepository.findByIdWithLeader(studyId)
-                .orElseThrow(StudyNotFoundException::new);
-
+            .orElseThrow(StudyNotFoundException::new);
         int currentMembers = (int) studyMemberRepository.countByStudy(study);
 
         List<Category> categories = study.getInterests().stream()
-                .map(StudyCategory::getCategory)
-                .collect(Collectors.toList());
-
+            .map(StudyCategory::getCategory)
+            .collect(Collectors.toList());
         List<String> conditions = study.getConditions().stream()
-                .map(StudyCondition::getContent)
-                .toList();
-
+            .map(StudyCondition::getContent)
+            .toList();
         return new StudyDetailResponseDto(
-                study.getFileKey(),
-                study.getTitle(),
-                study.getDescription(),
-                study.getDetailDescription(),
-                categories,
-                study.getRegion(),
-                study.getStudyTime(),
-                conditions,
-                currentMembers,
-                study.getMaxMembers()
+            study.getFileKey(),
+            study.getTitle(),
+            study.getDescription(),
+            study.getDetailDescription(),
+            categories,
+            study.getRegion(),
+            study.getStudyTime(),
+            conditions,
+            currentMembers,
+            study.getMaxMembers()
         );
+    }
+
+    @Override
+    @Transactional
+    public void leaveStudy(User user, Long studyId) {
+        Study study = studyRepository.findById(studyId)
+            .orElseThrow(StudyNotFoundException::new);
+
+        StudyMember studyMember = studyMemberRepository.findByStudyAndUser(study, user)
+            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (studyMember.getRole() == StudyMemberRole.LEADER) {
+            throw new BusinessException(ErrorCode.CANNOT_LEAVE_AS_LEADER);
+        }
+
+        studyMemberRepository.delete(studyMember);
     }
 
     private Pageable createPageable(int page, int size) {

--- a/src/main/java/com/pado/domain/study/service/StudyServiceImpl.java
+++ b/src/main/java/com/pado/domain/study/service/StudyServiceImpl.java
@@ -3,7 +3,6 @@ package com.pado.domain.study.service;
 import com.pado.domain.shared.entity.Category;
 import com.pado.domain.shared.entity.Region;
 import com.pado.domain.study.dto.request.StudyCreateRequestDto;
-import com.pado.domain.study.dto.response.MyStudyResponseDto;
 import com.pado.domain.study.dto.response.StudyDetailResponseDto;
 import com.pado.domain.study.dto.response.StudyListResponseDto;
 import com.pado.domain.study.dto.response.StudySimpleResponseDto;
@@ -118,6 +117,29 @@ public class StudyServiceImpl implements StudyService {
         }
 
         studyMemberRepository.delete(studyMember);
+    }
+
+    @Override
+    @Transactional
+    public void updateStudy(User user, Long studyId, StudyCreateRequestDto requestDto) {
+        Study study = studyRepository.findById(studyId)
+            .orElseThrow(StudyNotFoundException::new);
+
+        if (!study.getLeader().getId().equals(user.getId())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_STUDY_LEADER_ONLY);
+        }
+
+        study.update(
+            requestDto.title(),
+            requestDto.description(),
+            requestDto.detail_description(),
+            requestDto.region(),
+            requestDto.study_time(),
+            requestDto.max_members(),
+            requestDto.file_key(),
+            requestDto.interests(),
+            requestDto.conditions()
+        );
     }
 
     private Pageable createPageable(int page, int size) {

--- a/src/main/java/com/pado/domain/user/controller/UserController.java
+++ b/src/main/java/com/pado/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.pado.domain.user.controller;
 
 import com.pado.domain.study.dto.response.MyApplicationResponseDto;
+import com.pado.domain.study.dto.response.MyStudyResponseDto;
 import com.pado.domain.user.dto.UserDetailResponseDto;
 import com.pado.domain.user.dto.UserSimpleResponseDto;
 import com.pado.domain.user.dto.UserStudyResponseDto;
@@ -32,36 +33,36 @@ public class UserController {
     private final UserService userService;
 
     @Api404UserNotFoundError
-    @Operation(summary = "유저 정보 조회", description = "인증 토큰을 통해 현재 로그인된 사용자의 주요 정보(닉네임, 이미지 URL)를 조회합니다.")
+    @Operation(summary = "내 정보 조회 (간략)", description = "인증 토큰을 통해 현재 로그인된 사용자의 주요 정보(닉네임, 이미지 URL)를 조회합니다.")
     @ApiResponse(
         responseCode = "200", description = "유저 정보 조회 성공",
         content = @Content(schema = @Schema(implementation = UserSimpleResponseDto.class))
     )
-    @GetMapping("/me") // 경로를 /me로 변경하여 일관성 유지
+    @GetMapping("/me")
     public ResponseEntity<UserSimpleResponseDto> getSimpleUserInfo(
         @Parameter(hidden = true) @CurrentUser User user) {
         return ResponseEntity.ok(userService.getUserSimple(user));
     }
 
     @Api404UserNotFoundError
-    @Operation(summary = "유저 세부 정보 조회", description = "인증 토큰을 통해 현재 로그인된 사용자의 세부 정보(관심분야, 지역 포함)를 조회합니다.")
+    @Operation(summary = "내 정보 조회 (상세)", description = "인증 토큰을 통해 현재 로그인된 사용자의 세부 정보(관심분야, 지역 포함)를 조회합니다.")
     @ApiResponse(
         responseCode = "200", description = "세부 정보 조회 성공",
         content = @Content(schema = @Schema(implementation = UserDetailResponseDto.class))
     )
-    @GetMapping("/me/detail") // 경로를 /me/detail로 변경하여 일관성 유지
+    @GetMapping("/me/detail")
     public ResponseEntity<UserDetailResponseDto> getDetailUserInfo(
         @Parameter(hidden = true) @CurrentUser User user) {
         return ResponseEntity.ok(userService.getUserDetail(user.getId()));
     }
 
     @Api404UserNotFoundError
-    @Operation(summary = "유저 스터디 정보 조회", description = "인증 토큰과 study_id를 통해 현재 로그인된 사용자의 스터디 정보(역할, 스터디 이름 포함)를 조회합니다.")
+    @Operation(summary = "내 스터디 정보 조회", description = "인증 토큰과 study_id를 통해 현재 로그인된 사용자의 스터디 정보(역할, 스터디 이름 포함)를 조회합니다.")
     @ApiResponse(
         responseCode = "200", description = "스터디 정보 조회 성공",
         content = @Content(schema = @Schema(implementation = UserStudyResponseDto.class))
     )
-    @GetMapping("/me/studies/{study_id}") // 경로를 /me/studies/{study_id}로 변경
+    @GetMapping("/me/studies/{study_id}")
     public ResponseEntity<UserStudyResponseDto> getStudyUserInfo(
         @PathVariable("study_id") Long studyId, @Parameter(hidden = true) @CurrentUser User user
     ) {
@@ -75,5 +76,15 @@ public class UserController {
         @Parameter(hidden = true) @CurrentUser User user
     ) {
         return ResponseEntity.ok(userService.getMyApplications(user));
+    }
+
+    @Operation(summary = "내가 참여중인 스터디 목록 조회", description = "현재 로그인한 사용자가 참여하고 있는 스터디 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/me/studies")
+    public ResponseEntity<List<MyStudyResponseDto>> getMyStudies(
+        @Parameter(hidden = true) @CurrentUser User user
+    ) {
+        List<MyStudyResponseDto> myStudies = userService.findMyStudies(user.getId());
+        return ResponseEntity.ok(myStudies);
     }
 }

--- a/src/main/java/com/pado/domain/user/controller/UserController.java
+++ b/src/main/java/com/pado/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.pado.domain.user.controller;
 
+import com.pado.domain.study.dto.response.MyApplicationResponseDto;
 import com.pado.domain.user.dto.UserDetailResponseDto;
 import com.pado.domain.user.dto.UserSimpleResponseDto;
 import com.pado.domain.user.dto.UserStudyResponseDto;
@@ -20,45 +21,59 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @Tag(name = "02. User", description = "인증된 사용자 정보 관련 API")
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
+
     private final UserService userService;
 
     @Api404UserNotFoundError
     @Operation(summary = "유저 정보 조회", description = "인증 토큰을 통해 현재 로그인된 사용자의 주요 정보(닉네임, 이미지 URL)를 조회합니다.")
     @ApiResponse(
-            responseCode = "200", description = "유저 정보 조회 성공",
-            content = @Content(schema = @Schema(implementation = UserSimpleResponseDto.class))
+        responseCode = "200", description = "유저 정보 조회 성공",
+        content = @Content(schema = @Schema(implementation = UserSimpleResponseDto.class))
     )
-    @GetMapping
-    public ResponseEntity<UserSimpleResponseDto> getSimpleUserInfo(@Parameter(hidden = true) @CurrentUser User user) {
+    @GetMapping("/me") // 경로를 /me로 변경하여 일관성 유지
+    public ResponseEntity<UserSimpleResponseDto> getSimpleUserInfo(
+        @Parameter(hidden = true) @CurrentUser User user) {
         return ResponseEntity.ok(userService.getUserSimple(user));
     }
 
     @Api404UserNotFoundError
     @Operation(summary = "유저 세부 정보 조회", description = "인증 토큰을 통해 현재 로그인된 사용자의 세부 정보(관심분야, 지역 포함)를 조회합니다.")
     @ApiResponse(
-            responseCode = "200", description = "세부 정보 조회 성공",
-            content = @Content(schema = @Schema(implementation = UserDetailResponseDto.class))
+        responseCode = "200", description = "세부 정보 조회 성공",
+        content = @Content(schema = @Schema(implementation = UserDetailResponseDto.class))
     )
-    @GetMapping("/detail")
-    public ResponseEntity<UserDetailResponseDto> getDetailUserInfo(@Parameter(hidden = true) @CurrentUser User user) {
+    @GetMapping("/me/detail") // 경로를 /me/detail로 변경하여 일관성 유지
+    public ResponseEntity<UserDetailResponseDto> getDetailUserInfo(
+        @Parameter(hidden = true) @CurrentUser User user) {
         return ResponseEntity.ok(userService.getUserDetail(user.getId()));
     }
 
     @Api404UserNotFoundError
     @Operation(summary = "유저 스터디 정보 조회", description = "인증 토큰과 study_id를 통해 현재 로그인된 사용자의 스터디 정보(역할, 스터디 이름 포함)를 조회합니다.")
     @ApiResponse(
-            responseCode = "200", description = "스터디 정보 조회 성공",
-            content = @Content(schema = @Schema(implementation = UserStudyResponseDto.class))
+        responseCode = "200", description = "스터디 정보 조회 성공",
+        content = @Content(schema = @Schema(implementation = UserStudyResponseDto.class))
     )
-    @GetMapping("/{study_id}")
+    @GetMapping("/me/studies/{study_id}") // 경로를 /me/studies/{study_id}로 변경
     public ResponseEntity<UserStudyResponseDto> getStudyUserInfo(
-            @PathVariable("study_id") Long studyId, @Parameter(hidden = true) @CurrentUser User user
+        @PathVariable("study_id") Long studyId, @Parameter(hidden = true) @CurrentUser User user
     ) {
         return ResponseEntity.ok(userService.getUserStudy(studyId, user));
+    }
+
+    @Operation(summary = "내가 신청한 스터디 목록 조회", description = "사용자가 자신이 신청한 스터디 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/me/studies/applications")
+    public ResponseEntity<List<MyApplicationResponseDto>> getMyApplications(
+        @Parameter(hidden = true) @CurrentUser User user
+    ) {
+        return ResponseEntity.ok(userService.getMyApplications(user));
     }
 }

--- a/src/main/java/com/pado/domain/user/service/UserService.java
+++ b/src/main/java/com/pado/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.pado.domain.user.service;
 
 import com.pado.domain.study.dto.response.MyApplicationResponseDto;
+import com.pado.domain.study.dto.response.MyStudyResponseDto;
 import com.pado.domain.user.dto.UserDetailResponseDto;
 import com.pado.domain.user.dto.UserSimpleResponseDto;
 import com.pado.domain.user.dto.UserStudyResponseDto;
@@ -20,4 +21,6 @@ public interface UserService {
     UserStudyResponseDto getUserStudy(Long studyId, User user);
 
     List<MyApplicationResponseDto> getMyApplications(User user);
+
+    List<MyStudyResponseDto> findMyStudies(Long userId);
 }

--- a/src/main/java/com/pado/domain/user/service/UserService.java
+++ b/src/main/java/com/pado/domain/user/service/UserService.java
@@ -1,15 +1,23 @@
 package com.pado.domain.user.service;
 
+import com.pado.domain.study.dto.response.MyApplicationResponseDto;
 import com.pado.domain.user.dto.UserDetailResponseDto;
 import com.pado.domain.user.dto.UserSimpleResponseDto;
 import com.pado.domain.user.dto.UserStudyResponseDto;
 import com.pado.domain.user.entity.User;
 
+import java.util.List;
+
 public interface UserService {
+
     //유저 주요 정보 검색
     UserSimpleResponseDto getUserSimple(User user);
+
     //유저 세부 정보 검색
     UserDetailResponseDto getUserDetail(Long userId);
+
     //유저 스터디 정보 검색
     UserStudyResponseDto getUserStudy(Long studyId, User user);
+
+    List<MyApplicationResponseDto> getMyApplications(User user);
 }

--- a/src/main/java/com/pado/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/pado/domain/user/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.pado.domain.user.service;
 
 import com.pado.domain.study.dto.response.MyApplicationResponseDto;
+import com.pado.domain.study.dto.response.MyStudyResponseDto;
 import com.pado.domain.study.entity.Study;
 import com.pado.domain.study.entity.StudyApplication;
 import com.pado.domain.study.entity.StudyMember;
@@ -76,6 +77,18 @@ public class UserServiceImpl implements UserService {
                 .status(app.getStatus().name())
                 .message(app.getMessage())
                 .build())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MyStudyResponseDto> findMyStudies(Long userId) {
+        List<Study> studies = studyRepository.findByUserId(userId);
+        return studies.stream()
+            .map(study -> new MyStudyResponseDto(
+                study.getId(),
+                study.getTitle()
+            ))
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/pado/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/pado/domain/user/service/UserServiceImpl.java
@@ -1,7 +1,10 @@
 package com.pado.domain.user.service;
 
+import com.pado.domain.study.dto.response.MyApplicationResponseDto;
 import com.pado.domain.study.entity.Study;
+import com.pado.domain.study.entity.StudyApplication;
 import com.pado.domain.study.entity.StudyMember;
+import com.pado.domain.study.repository.StudyApplicationRepository;
 import com.pado.domain.study.repository.StudyMemberRepository;
 import com.pado.domain.study.repository.StudyRepository;
 import com.pado.domain.user.dto.UserDetailResponseDto;
@@ -15,12 +18,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
+
     private final UserRepository userRepository;
     private final StudyRepository studyRepository;
     private final StudyMemberRepository studyMemberRepository;
+    private final StudyApplicationRepository studyApplicationRepository;
+
     @Override
     public UserSimpleResponseDto getUserSimple(User user) {
         return new UserSimpleResponseDto(user.getNickname(), user.getImage_key());
@@ -31,27 +40,42 @@ public class UserServiceImpl implements UserService {
     public UserDetailResponseDto getUserDetail(Long userId) {
         //영속성 컨텍스트 문제로 User를 바로 사용했을 시 Userinterest 조회가 안됨
         User user = userRepository.findWithInterestsById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         return new UserDetailResponseDto(
-                user.getNickname(),
-                user.getImage_key(),
-                user.getInterests().stream()
-                        .map(ui -> ui.getCategory().name())
-                        .toList(),
-                user.getRegion()
+            user.getNickname(),
+            user.getImage_key(),
+            user.getInterests().stream()
+                .map(ui -> ui.getCategory().name())
+                .toList(),
+            user.getRegion()
         );
     }
 
     @Override
     public UserStudyResponseDto getUserStudy(Long studyId, User user) {
         Study study = studyRepository.findById(studyId).orElseThrow(
-                () -> new BusinessException(ErrorCode.STUDY_NOT_FOUND)
+            () -> new BusinessException(ErrorCode.STUDY_NOT_FOUND)
         );
-
-        StudyMember studyMember = studyMemberRepository.findByStudyIdAndUserId(studyId, user.getId()).orElseThrow(
-                () -> new BusinessException(ErrorCode.USER_NOT_FOUND)
+        StudyMember studyMember = studyMemberRepository.findByStudyIdAndUserId(studyId,
+            user.getId()).orElseThrow(
+            () -> new BusinessException(ErrorCode.USER_NOT_FOUND)
         );
+        return new UserStudyResponseDto(user.getNickname(), user.getImage_key(), study.getTitle(),
+            studyMember.getRole());
+    }
 
-        return new UserStudyResponseDto(user.getNickname(), user.getImage_key(), study.getTitle(), studyMember.getRole());
+    @Override
+    @Transactional(readOnly = true)
+    public List<MyApplicationResponseDto> getMyApplications(User user) {
+        List<StudyApplication> applications = studyApplicationRepository.findByUserWithStudy(user);
+        return applications.stream()
+            .map(app -> MyApplicationResponseDto.builder()
+                .applicationId(app.getId())
+                .studyId(app.getStudy().getId())
+                .studyTitle(app.getStudy().getTitle())
+                .status(app.getStatus().name())
+                .message(app.getMessage())
+                .build())
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/pado/global/exception/common/ErrorCode.java
+++ b/src/main/java/com/pado/global/exception/common/ErrorCode.java
@@ -65,6 +65,10 @@ public enum ErrorCode {
         "승인 요청중인 유저를 찾을 수 없습니다."),
     CANNOT_KICK_LEADER(HttpStatus.BAD_REQUEST, "CANNOT_KICK_LEADER",
         "스터디 리더는 탈퇴시킬 수 없습니다. 먼저 리더를 위임해야 합니다."),
+    CANNOT_LEAVE_AS_LEADER(HttpStatus.BAD_REQUEST, "CANNOT_LEAVE_AS_LEADER",
+        "스터디 리더는 탈퇴할 수 없습니다. 먼저 다른 멤버에게 리더를 위임해야 합니다."),
+    INVALID_LEADER_DELEGATION_TARGET(HttpStatus.BAD_REQUEST, "INVALID_LEADER_DELEGATION_TARGET",
+        "유효하지 않은 리더 위임 대상입니다."),
 
 
     // Material Domain

--- a/src/main/java/com/pado/global/exception/common/ErrorCode.java
+++ b/src/main/java/com/pado/global/exception/common/ErrorCode.java
@@ -61,7 +61,11 @@ public enum ErrorCode {
     ALREADY_APPLIED(HttpStatus.CONFLICT, "ALREADY_APPLIED", "이미 스터디에 참여 신청했습니다."),
     STUDY_NOT_RECRUITING(HttpStatus.BAD_REQUEST, "STUDY_NOT_RECRUITING", "모집 중인 스터디가 아닙니다."),
     STUDY_FULL(HttpStatus.BAD_REQUEST, "STUDY_FULL", "스터디 정원이 가득 찼습니다."),
-    STUDY_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_APPLICATION_NOT_FOUND", "승인 요청중인 유저를 찾을 수 없습니다."),
+    STUDY_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_APPLICATION_NOT_FOUND",
+        "승인 요청중인 유저를 찾을 수 없습니다."),
+    CANNOT_KICK_LEADER(HttpStatus.BAD_REQUEST, "CANNOT_KICK_LEADER",
+        "스터디 리더는 탈퇴시킬 수 없습니다. 먼저 리더를 위임해야 합니다."),
+
 
     // Material Domain
     MATERIAL_NOT_FOUND(HttpStatus.NOT_FOUND, "MATERIAL_NOT_FOUND", "자료를 찾을 수 없습니다."),
@@ -85,9 +89,12 @@ public enum ErrorCode {
 
     // QUIZ
     QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "QUIZ_NOT_FOUND", "퀴즈를 찾을 수 없습니다."),
-    FILE_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_PROCESSING_FAILED", "파일 처리 중 오류가 발생했습니다."),
-    API_RESPONSE_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "API_RESPONSE_INVALID", "Gemini AI API가 유효하지 않은 결과를 반환하였습니다."),
-    UNSUPPORTED_QUESTION_TYPE(HttpStatus.BAD_REQUEST, "UNSUPPORTED_QUESTION_TYPE", "지원하지 않는 문제 형식입니다."),
+    FILE_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_PROCESSING_FAILED",
+        "파일 처리 중 오류가 발생했습니다."),
+    API_RESPONSE_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "API_RESPONSE_INVALID",
+        "Gemini AI API가 유효하지 않은 결과를 반환하였습니다."),
+    UNSUPPORTED_QUESTION_TYPE(HttpStatus.BAD_REQUEST, "UNSUPPORTED_QUESTION_TYPE",
+        "지원하지 않는 문제 형식입니다."),
     QUIZ_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "QUIZ_NOT_ACTIVE", "퀴즈 상태가 Active가 아닙니다."),
     QUIZ_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "QUIZ_ALREADY_COMPLETED", "이미 완료된 퀴즈입니다."),
     SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBMISSION_NOT_FOUND", "제출 정보를 찾을 수 없습니다."),
@@ -104,8 +111,8 @@ public enum ErrorCode {
     INVALID_SUBSCRIBE_PATH(HttpStatus.BAD_REQUEST, "INVALID_SUBSCRIBE_PATH", "구독 경로가 잘못되었습니다."),
     CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_MESSAGE_NOT_FOUND", "채팅 메시지를 찾을 수 없습니다."),
     CHAT_MESSAGE_TOO_LONG(HttpStatus.BAD_REQUEST, "CHAT_MESSAGE_TOO_LONG", "메시지가 너무 깁니다."),
-    WEBSOCKET_CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WEBSOCKET_CONNECTION_FAILED", "웹소켓 연결에 실패했습니다.");
-
+    WEBSOCKET_CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WEBSOCKET_CONNECTION_FAILED",
+        "웹소켓 연결에 실패했습니다.");
     public final HttpStatus status;
     public final String code;
     public final String message;


### PR DESCRIPTION
## ✨ 요약

> 스터디 멤버 관리와 관련된 핵심 기능(목록 조회, 강제 탈퇴, 리더 위임, 자진 탈퇴, 신청 취소/조회, 정보 수정)을 구현하고, API 엔드포인트의 일관성과 명확성을 높이기 위해 기존 API 경로를 RESTful 원칙에 맞게 재설계했습니다.

## 🔗 작업 내용
GET /api/studies/{study_id}/members: 스터디원 및 신청자 목록 조회 기능 (리더 전용)
DELETE /api/studies/{study_id}/members/{member_id}: 스터디원 강제 탈퇴 기능 (리더 전용)
PUT /api/studies/{study_id}/leader: 스터디 리더 권한 위임 기능 (리더 전용)
DELETE /api/studies/{study_id}/membership: 스터디 자진 탈퇴 기능 (멤버 전용)
DELETE /api/studies/{study_id}/applications/me: 스터디 신청 취소 기능
GET /api/users/me/studies/applications: 내가 신청한 스터디 목록 조회 기능
PATCH /api/studies/{study_id}: 스터디 정보 수정 기능 (리더 전용) 구현

기존 API 리팩터링

GET /api/studies/me 경로를 GET /api/users/me/studies로 변경하고 User 도메인으로 이관
PATCH /api/studies/{study_id}/applications/{application_id} 경로 변수명을 {app_id}로 명확화

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #113 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)