### PR TITLE
refactor: 퀴즈 잔여 시간 계산을 LocalDateTime에서 Instant 기반으로 변경

### DIFF
--- a/src/main/java/com/pado/domain/quiz/entity/QuizSubmission.java
+++ b/src/main/java/com/pado/domain/quiz/entity/QuizSubmission.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,16 +48,16 @@ public class QuizSubmission {
     private Long version;
 
     @Column(name = "started_at", nullable = false, updatable = false)
-    private LocalDateTime startedAt;
+    private Instant startedAt;
 
     @Column(name = "submitted_at")
-    private LocalDateTime submittedAt;
+    private Instant submittedAt;
 
     @OneToOne(mappedBy = "quizSubmission", cascade = CascadeType.ALL, orphanRemoval = true)
     private QuizPointLog pointLog;
 
     @Builder
-    public QuizSubmission(User user, LocalDateTime startedAt) {
+    public QuizSubmission(User user, Instant startedAt) {
         this.quiz = null;
         this.user = user;
         this.status = SubmissionStatus.IN_PROGRESS;
@@ -65,7 +65,7 @@ public class QuizSubmission {
         this.totalQuestions = 0;
         this.startedAt = (startedAt != null)
                 ? startedAt
-                : LocalDateTime.now();
+                : Instant.now();
     }
 
     protected void setQuiz(Quiz quiz) {
@@ -80,7 +80,7 @@ public class QuizSubmission {
 
         this.score = finalScore;
         this.status = SubmissionStatus.COMPLETED;
-        this.submittedAt = LocalDateTime.now();
+        this.submittedAt = Instant.now();
     }
 
     public void addAnswerSubmission(AnswerSubmission answer) {

--- a/src/main/java/com/pado/domain/quiz/mapper/QuizDtoMapper.java
+++ b/src/main/java/com/pado/domain/quiz/mapper/QuizDtoMapper.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Clock;
 import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +84,7 @@ public class QuizDtoMapper {
         );
     }
 
-    private Long calculateRemainingSeconds(Integer timeLimitSeconds, LocalDateTime startTime) {
+    private Long calculateRemainingSeconds(Integer timeLimitSeconds, Instant startTime) {
         if (timeLimitSeconds == null || timeLimitSeconds <= 0) {
             return null;
         }
@@ -93,7 +93,7 @@ public class QuizDtoMapper {
             return timeLimitSeconds.longValue();
         }
 
-        long secondsElapsed = Duration.between(startTime, LocalDateTime.now(clock)).getSeconds();
+        long secondsElapsed = Duration.between(startTime, Instant.now(clock)).getSeconds();
         long secondsRemaining = timeLimitSeconds - secondsElapsed;
 
         return Math.max(0, secondsRemaining);


### PR DESCRIPTION
## ✨ 요약

> 기존 LocalDateTime 기반의 시간 필드를 Instant로 변경하여 서버/환경의 타임존 설정과 무관하게 일관된 시간 계산이 가능하도록 리팩터링했습니다.

## 🔗 작업 내용

- QuizSubmission의 startedAt, submittedAt을 Instant로 변경
- QuizDtoMapper의 잔여 시간 계산을 Instant 기반으로 변경

## 🔗 관련 이슈

- Close #142 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved timestamp handling for more accurate quiz time tracking and duration calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->