### PR TITLE
fix: CI/CD 배포 시 GEMINI_API_KEY 환경 변수 누락 문제 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -330,6 +330,7 @@ jobs:
             MAIL_VERIFICATION_EXP_SECONDS=${{ secrets.MAIL_VERIFICATION_EXP_SECONDS || '300' }}
             REDIS_HOST=${{ secrets.REDIS_HOST }}
             REDIS_PORT=${{ secrets.REDIS_PORT || '6379' }}
+            GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}
             EOF
             
             NEW_CONTAINER_ID=$(sudo docker run -d --name "$NEW_NAME" -p ${TARGET_PORT}:8080 \


### PR DESCRIPTION
## ✨ 요약
> EC2 배포 시 애플리케이션 컨테이너에서 GEMINI_API_KEY 환경 변수를 정상적으로 읽을 수 있도록 .env 파일 생성 과정에 해당 키를 추가하였습니다.

## 🔗 작업 내용

- `build-and-deploy` job에서 `.env` 파일 생성 시 `GEMINI_API_KEY` 주입


## 🔗 관련 이슈

- Close #159 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to include necessary environment variable for production and staging environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->